### PR TITLE
Bugfixes/small misses

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -16,5 +16,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: v1.38
+          version: v1.42
           args: -E gosec,goconst,nestif,interfacer,bodyclose,rowserrcheck

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -17,4 +17,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2.5.2
         with:
           version: v1.42
-          args: -E gosec,goconst,nestif,interfacer,bodyclose,rowserrcheck
+          args: -E gosec,goconst,nestif,bodyclose,rowserrcheck

--- a/api/api.go
+++ b/api/api.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Setup Setup a fiber app with all of its routes
-func Setup(url string) *fiber.App {
+func Setup(url string, archivePath string) *fiber.App {
 	// Fiber instance
 	app := fiber.New()
 	app.Use(middleware.TokenMiddleware(url))
@@ -20,7 +20,7 @@ func Setup(url string) *fiber.App {
 		return sda.Files(c, c.Params(("+")))
 	})
 	app.Get("/files/:fileId", func(c *fiber.Ctx) error {
-		return sda.Download(c, c.Params(("fileId")))
+		return sda.Download(c, c.Params(("fileId")), archivePath)
 	})
 
 	// S3 endpoints

--- a/api/sda/sda.go
+++ b/api/sda/sda.go
@@ -81,7 +81,8 @@ func Download(c *fiber.Ctx, fileID string) error {
 	}
 
 	// Get archive file handle
-	file, err := os.Open(fileDetails.ArchivePath)
+	path := fmt.Sprintf("%s/%s", archivePath, fileDetails.ArchivePath)
+	file, err := os.Open(path)
 	if err != nil {
 		log.Errorf("could not find archive file %s, %s", fileDetails.ArchivePath, err)
 		return fiber.NewError(500, "could not find archive file")

--- a/api/sda/sda.go
+++ b/api/sda/sda.go
@@ -1,6 +1,7 @@
 package sda
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 
@@ -42,7 +43,11 @@ func Files(c *fiber.Ctx, datasetID string) error {
 			log.Errorf("database query failed, %s", err)
 			return c.SendStatus(fiber.StatusInternalServerError)
 		}
-		return c.JSON(files)
+		fileshttp, _ := database.DB.GetFiles("https://" + datasetID)
+
+		result := append(files, fileshttp...)
+
+		return c.JSON(result)
 	}
 
 	// no matches in database with given datasetID
@@ -50,7 +55,7 @@ func Files(c *fiber.Ctx, datasetID string) error {
 }
 
 // Download serves file contents as bytes
-func Download(c *fiber.Ctx, fileID string) error {
+func Download(c *fiber.Ctx, fileID string, archivePath string) error {
 	log.Debugf("request to /file/%s from %s", fileID, c.Context().RemoteIP().String())
 
 	// Check user has permissions for this file (as part of a dataset)
@@ -63,7 +68,7 @@ func Download(c *fiber.Ctx, fileID string) error {
 	datasets := c.Locals("datasets").([]string)
 	permission := false
 	for d := range datasets {
-		if datasets[d] == dataset {
+		if datasets[d] == dataset || "https://"+datasets[d] == dataset {
 			permission = true
 			break
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,7 +24,7 @@ func main() {
 	defer db.Close()
 	database.DB = db
 	// app contains the web app and endpoints
-	app := api.Setup(conf.OIDC.ConfigurationURL)
+	app := api.Setup(conf.OIDC.ConfigurationURL, conf.App.ArchivePath)
 
 	// Start server
 	log.Fatal(app.Listen(conf.App.Host + ":" + strconv.Itoa(conf.App.Port)))

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,7 @@ app:
   host: "localhost"
   port: 8080
   logLevel: "debug"
+  archivePath: "/"
 
 c4gh:
   filepath: "test/doa.sec.pem"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,8 @@ type AppConfig struct {
 	// Stores the Crypt4GH private key if the two configs above are set
 	// Unconfigurable. Depends on Crypt4GHKeyFile and Crypt4GHPassFile
 	Crypt4GHKey *[32]byte
+
+	ArchivePath string
 }
 
 type OIDCConfig struct {
@@ -106,6 +108,7 @@ func NewConfig() (*ConfigMap, error) {
 	viper.SetDefault("app.host", "localhost")
 	viper.SetDefault("app.port", 8080)
 	viper.SetDefault("app.LogLevel", "info")
+	viper.SetDefault("app.archivePath", "/")
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
@@ -154,6 +157,7 @@ func NewConfig() (*ConfigMap, error) {
 func (c *ConfigMap) appConfig() error {
 	c.App.Host = viper.GetString("app.host")
 	c.App.Port = viper.GetInt("app.port")
+	c.App.ArchivePath = viper.GetString("app.archivePath")
 
 	var err error
 	c.App.Crypt4GHKey, err = GetC4GHKey()

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -61,7 +61,7 @@ func VerifyJWT(o OIDCDetails, token string) (jwt.Token, error) {
 		return nil, err
 	}
 	key, valid := keyset.Get(0)
-	if valid != true {
+	if !valid {
 		log.Errorf("cannot get key from set , %s", err)
 	}
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -202,7 +202,7 @@ func GetPermissions(visas []byte) ([]string, error) {
 		datasetFull := visa.Dataset
 		datasetParts := strings.Split(datasetFull, "://")
 		datasetName := datasetParts[len(datasetParts)-1]
-		exists, err := database.DB.CheckDataset(datasetName)
+		exists, err := database.DB.CheckDataset(datasetFull)
 		if err != nil {
 			log.Debugf("visa contained dataset %s which doesn't exist in this instance, skip", datasetName)
 			continue


### PR DESCRIPTION
- add configurable archive path
- get dataset via url so it can be matched with permissions
- get key RSA256 as it will not be inferred by the library: see details at: https://github.com/lestrrat-go/jwx/blob/933902ed39c2baed3fedc83f4eea05973fc7b6bb/docs/99-faq.md#why-dont-you-automatically-infer-the-algorithm-for-jwsverify-