### PR TITLE
fix coordinate to reader translation bug

### DIFF
--- a/api/sda/sda.go
+++ b/api/sda/sda.go
@@ -186,15 +186,22 @@ func Download(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "endCoordinate must be an integer", 400)
 			return
 		}
+		if end < start {
+			log.Errorf("endCoordinate=%d must be greater than startCoordinate=%d", end, start)
+			http.Error(w, "endCoordinate must be greater than startCoordinate", 400)
+			return
+		}
+		// API query params take a coordinate range to read "start...end"
+		// But Crypt4GHReader takes a start byte and number of bytes to read "start...(end-start)"
+		bytesToRead := end - start
 		coordinates.NumberLengths = 2
-		coordinates.Lengths = []uint64{start, end}
+		coordinates.Lengths = []uint64{start, bytesToRead}
 	} else {
 		coordinates = nil
 	}
 
 	// Get file stream
 	fileStream, err := files.StreamFile(fileDetails.Header, file, coordinates)
-	log.Debugf("HELLO %v", err)
 	if err != nil {
 		log.Errorf("could not prepare file for streaming, %s", err)
 		http.Error(w, "file stream error", 500)

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -150,6 +150,7 @@ func (dbs *SQLdb) getFiles(datasetID string) ([]*FileInfo, error) {
 		"decrypted_file_size, decrypted_file_checksum, decrypted_file_checksum_type, file_status from " +
 		"local_ega_ebi.file a, local_ega_ebi.file_dataset b WHERE dataset_id = $1 AND a.file_id=b.file_id;"
 
+	// nolint:rowserrcheck
 	rows, err := db.Query(query, datasetID)
 	if err != nil {
 		log.Error(err)

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -151,7 +151,7 @@ func (dbs *SQLdb) getFiles(datasetID string) ([]*FileInfo, error) {
 		"local_ega_ebi.file a, local_ega_ebi.file_dataset b WHERE dataset_id = $1 AND a.file_id=b.file_id;"
 
 	rows, err := db.Query(query, datasetID)
-	if rows.Err() != nil || err != nil {
+	if err != nil {
 		log.Error(err)
 		return nil, err
 	}


### PR DESCRIPTION
The download endpoint takes the range parameters as absolute values:
e.g. `?startCoordinate=50&endCoordinate=100`

but `Crypt4GHReader` takes coordinates as `startCoordinate...bytesToRead`

This caused a bug where the example query parameters would return 100 bytes instead of 50.