### PR TITLE
adjust config #minor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ test/*.pem
 test/*.crt
 test/*.csr
 test/*.key
+
+test/crypt4gh

--- a/README.md
+++ b/README.md
@@ -9,8 +9,16 @@
 ## Configuration
 Configuration variables are set in [config.yaml](config.yaml).
 
+### Local Setup
+
+For local setup run
+```
+cd test && ./setup.sh && cd ..
+```
+
 ## Run
 Requires [sda-db](https://github.com/neicnordic/sda-db) to be running beforehand.
 ```
 go run cmd/main.go
 ```
+

--- a/api/api.go
+++ b/api/api.go
@@ -25,9 +25,9 @@ func Setup() *http.Server {
 	log.Info("(2/5) Registering endpoint handlers")
 	r := mux.NewRouter().SkipClean(true)
 
-	r.Handle("/metadata/datasets", middleware.TokenMiddleware(http.HandlerFunc(sda.Datasets)))
-	r.Handle("/metadata/datasets/{dataset:[A-Za-z0-9-_.~:/?#@!$&'()*+,;=]+}/files", middleware.TokenMiddleware(http.HandlerFunc(sda.Files)))
-	r.Handle("/files/{fileid}", middleware.TokenMiddleware(http.HandlerFunc(sda.Download)))
+	r.Handle("/metadata/datasets", middleware.TokenMiddleware(http.HandlerFunc(sda.Datasets))).Methods("GET")
+	r.Handle("/metadata/datasets/{dataset:[A-Za-z0-9-_.~:/?#@!$&'()*+,;=]+}/files", middleware.TokenMiddleware(http.HandlerFunc(sda.Files))).Methods("GET")
+	r.Handle("/files/{fileid}", middleware.TokenMiddleware(http.HandlerFunc(sda.Download))).Methods("GET")
 	r.HandleFunc("/health", healthResponse).Methods("GET")
 
 	// Configure TLS settings

--- a/api/api.go
+++ b/api/api.go
@@ -13,6 +13,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// healthResponse
+func healthResponse(w http.ResponseWriter, r *http.Request) {
+	// ok response to health
+	w.WriteHeader(http.StatusOK)
+}
+
 // Setup configures the web server and registers the routes
 func Setup() *http.Server {
 	// Set up routing
@@ -22,6 +28,7 @@ func Setup() *http.Server {
 	r.Handle("/metadata/datasets", middleware.TokenMiddleware(http.HandlerFunc(sda.Datasets)))
 	r.Handle("/metadata/datasets/{dataset:[A-Za-z0-9-_.~:/?#@!$&'()*+,;=]+}/files", middleware.TokenMiddleware(http.HandlerFunc(sda.Files)))
 	r.Handle("/files/{fileid}", middleware.TokenMiddleware(http.HandlerFunc(sda.Download)))
+	r.HandleFunc("/health", healthResponse).Methods("GET")
 
 	// Configure TLS settings
 	log.Info("(3/5) Configuring TLS")

--- a/api/sda/sda.go
+++ b/api/sda/sda.go
@@ -128,7 +128,7 @@ func Download(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get archive file handle
-	path := filepath.Join(config.Config.App.ArchivePath, fileDetails.ArchivePath)
+	path := filepath.Join(config.Config.Archive.Posix.Location, fileDetails.ArchivePath)
 	file, err := os.Open(path)
 	if err != nil {
 		log.Errorf("could not find archive file %s, %s", fileDetails.ArchivePath, err)

--- a/config.yaml
+++ b/config.yaml
@@ -44,4 +44,5 @@ db:
 
 oidc:
   # oidc configuration API must have values for "userinfo_endpoint" and "jwks_uri"
-  ConfigurationURL: "https://login.elixir-czech.org/oidc/.well-known/openid-configuration"
+  configuration:
+    url: "https://login.elixir-czech.org/oidc/.well-known/openid-configuration"

--- a/config.yaml
+++ b/config.yaml
@@ -3,8 +3,10 @@ app:
   port: 8080
   tlscert: "test/tls.crt"
   tlskey: "test/tls.key"
-  logLevel: "debug"
   archivePath: "/"
+
+log:
+  level: "debug"
 
 session:
   # session key expiration time in seconds

--- a/config.yaml
+++ b/config.yaml
@@ -3,10 +3,14 @@ app:
   port: 8080
   tlscert: "test/tls.crt"
   tlskey: "test/tls.key"
-  archivePath: "/"
 
 log:
   level: "debug"
+
+# posix is only supported at the moment
+archive:
+  type: "posix"
+  location: "/"
 
 session:
   # session key expiration time in seconds
@@ -25,8 +29,8 @@ session:
 
 c4gh:
   # crypt4gh private key for decrypting archived files
-  filepath: "test/doa.sec.pem"
-  passphrase: "doa"
+  filepath: "test/download.sec.pem"
+  passphrase: "passphrase"
 
 db:
   host: "localhost"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -150,7 +150,7 @@ func NewConfig() (*ConfigMap, error) {
 		}
 	}
 	requiredConfVars := []string{
-		"db.host", "db.user", "db.password", "db.database", "c4gh.filepath", "c4gh.passphrase", "oidc.ConfigurationURL",
+		"db.host", "db.user", "db.password", "db.database", "c4gh.filepath", "c4gh.passphrase", "oidc.configuration.url",
 	}
 
 	if viper.GetString("archive.type") == S3 {
@@ -180,7 +180,7 @@ func NewConfig() (*ConfigMap, error) {
 	c.applyDefaults()
 	c.sessionConfig()
 	c.configArchive()
-	c.OIDC.ConfigurationURL = viper.GetString("oidc.ConfigurationURL")
+	c.OIDC.ConfigurationURL = viper.GetString("oidc.configuration.url")
 	err := c.appConfig()
 	if err != nil {
 		return nil, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -195,8 +195,9 @@ func NewConfig() (*ConfigMap, error) {
 }
 
 // applyDefaults set default values for web server and session
+// default to host 0.0.0.0 as it will the main way we deploy this application
 func (c *ConfigMap) applyDefaults() {
-	viper.SetDefault("app.host", "localhost")
+	viper.SetDefault("app.host", "0.0.0.0")
 	viper.SetDefault("app.port", 8080)
 	viper.SetDefault("session.expiration", -1)
 	viper.SetDefault("session.secure", true)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,15 +131,6 @@ func NewConfig() (*ConfigMap, error) {
 		viper.SetConfigFile(viper.GetString("configFile"))
 	}
 
-	// defaults
-	viper.SetDefault("app.host", "localhost")
-	viper.SetDefault("app.port", 8080)
-	viper.SetDefault("app.logLevel", "info")
-	viper.SetDefault("app.archivePath", "/")
-	viper.SetDefault("session.expiration", -1)
-	viper.SetDefault("session.secure", true)
-	viper.SetDefault("session.httponly", true)
-
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 			log.Infoln("No config file found, using ENVs only")
@@ -169,6 +160,7 @@ func NewConfig() (*ConfigMap, error) {
 	}
 
 	c := &ConfigMap{}
+	c.applyDefaults()
 	c.sessionConfig()
 	c.OIDC.ConfigurationURL = viper.GetString("oidc.ConfigurationURL")
 	err := c.appConfig()
@@ -182,6 +174,16 @@ func NewConfig() (*ConfigMap, error) {
 	}
 
 	return c, nil
+}
+
+// applyDefaults set default values for web server and session
+func (c *ConfigMap) applyDefaults() {
+	viper.SetDefault("app.host", "localhost")
+	viper.SetDefault("app.port", 8080)
+	viper.SetDefault("app.archivePath", "/")
+	viper.SetDefault("session.expiration", -1)
+	viper.SetDefault("session.secure", true)
+	viper.SetDefault("session.httponly", true)
 }
 
 // appConfig sets required settings

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -202,6 +202,7 @@ func (c *ConfigMap) applyDefaults() {
 	viper.SetDefault("session.expiration", -1)
 	viper.SetDefault("session.secure", true)
 	viper.SetDefault("session.httponly", true)
+	viper.SetDefault("log.level", "info")
 }
 
 // configArchive provides configuration for the archive storage

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,11 +33,6 @@ type AppConfig struct {
 	// Optional. Default value 8080
 	Port int
 
-	// Logging level
-	// Optional. Default value debug
-	// Possible values error, fatal, info, panic, warn, trace, debug
-	LogLevel string
-
 	// TLS server certificate for HTTPS
 	// Optional. Defaults to empty
 	TLSCert string
@@ -162,8 +157,8 @@ func NewConfig() (*ConfigMap, error) {
 		}
 	}
 
-	if viper.IsSet("app.LogLevel") {
-		stringLevel := viper.GetString("app.logLevel")
+	if viper.IsSet("log.level") {
+		stringLevel := viper.GetString("log.level")
 		intLevel, err := log.ParseLevel(stringLevel)
 		if err != nil {
 			log.Printf("Log level '%s' not supported, setting to 'trace'", stringLevel)
@@ -196,7 +191,6 @@ func (c *ConfigMap) appConfig() error {
 	c.App.TLSCert = viper.GetString("app.tlscert")
 	c.App.TLSKey = viper.GetString("app.tlskey")
 	c.App.ArchivePath = viper.GetString("app.archivePath")
-	c.App.LogLevel = viper.GetString("app.logLevel")
 
 	var err error
 	c.App.Crypt4GHKey, err = GetC4GHKey()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -67,8 +67,7 @@ func (suite *TestSuite) TestAppConfig() {
 	viper.Set("app.port", 1234)
 	viper.Set("app.tlscert", "test")
 	viper.Set("app.tlskey", "test")
-	viper.Set("app.archivePath", "/test")
-	viper.Set("app.logLevel", "debug")
+	viper.Set("log.logLevel", "debug")
 
 	viper.Set("db.sslmode", "disable")
 
@@ -87,7 +86,15 @@ func (suite *TestSuite) TestAppConfig() {
 	assert.Equal(suite.T(), 1234, c.App.Port)
 	assert.Equal(suite.T(), "test", c.App.TLSCert)
 	assert.Equal(suite.T(), "test", c.App.TLSKey)
-	assert.Equal(suite.T(), "/test", c.App.ArchivePath)
+}
+
+func (suite *TestSuite) TestArchiveConfig() {
+	viper.Set("archive.type", POSIX)
+	viper.Set("archive.location", "/test")
+
+	c := &ConfigMap{}
+	c.configArchive()
+	assert.Equal(suite.T(), "/test", c.Archive.Posix.Location)
 
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -88,7 +88,6 @@ func (suite *TestSuite) TestAppConfig() {
 	assert.Equal(suite.T(), "test", c.App.TLSCert)
 	assert.Equal(suite.T(), "test", c.App.TLSKey)
 	assert.Equal(suite.T(), "/test", c.App.ArchivePath)
-	assert.Equal(suite.T(), "debug", c.App.LogLevel)
 
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var requiredConfVars = []string{
-	"db.host", "db.user", "db.password", "db.database", "c4gh.filepath", "c4gh.passphrase", "oidc.ConfigurationURL",
+	"db.host", "db.user", "db.password", "db.database", "c4gh.filepath", "c4gh.passphrase", "oidc.configuration.url",
 }
 
 type TestSuite struct {
@@ -27,7 +27,7 @@ func (suite *TestSuite) SetupTest() {
 	viper.Set("db.database", "test")
 	viper.Set("c4gh.filepath", "test")
 	viper.Set("c4gh.passphrase", "test")
-	viper.Set("oidc.ConfigurationURL", "test")
+	viper.Set("oidc.configuration.url", "test")
 }
 
 func (suite *TestSuite) TearDownTest() {

--- a/test/README.md
+++ b/test/README.md
@@ -1,8 +1,16 @@
 # Test
 
+## TLDR;
+
+For fast setup use:
+```
+$ ./setup.sh
+```
+
+## Steps
 Key pair can be generated with [crypt4gh](https://github.com/elixir-oslo/crypt4gh).
 ```
-$ crypt4gh generate --name=doa
+$ crypt4gh generate --name=download --password=passphrase
 ```
 
 Self-signed certificate for TLS can be generated with [makecert.sh](makecert.sh).

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# create certs
+source ./makecert.sh
+
+# https://github.com/elixir-oslo/crypt4gh
+curl -fsSL https://raw.githubusercontent.com/elixir-oslo/crypt4gh/master/install.sh | sh -s -- -b .
+
+# run crypt4gh to generate password
+./crypt4gh generate --name=download --password=passphrase


### PR DESCRIPTION
- make it easier to configure the app in helm chart in a similar fashion as `sda-pipeline` deployments (`LOG_LEVEL`, `ARCHIVE_TYPE`, `ARCHIVE_LOCATION`, `OIDC_CONFIGURATION_URL`)  
- Related https://github.com/neicnordic/sda-helm/pull/100
- move defaults to a single function
- fix default `APP_HOST` to `0.0.0.0` to make it easier to deploy in helm
- restricted endpoints to `GET` only
- other small fixes