### PR TITLE
fix datasets url pattern for EGA dataset ids

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -26,7 +26,7 @@ func Setup() *http.Server {
 	r := mux.NewRouter().SkipClean(true)
 
 	r.Handle("/metadata/datasets", middleware.TokenMiddleware(http.HandlerFunc(sda.Datasets))).Methods("GET")
-	r.Handle("/metadata/datasets/{dataset:[https?://[^\\s/$.?#].[^\\s]+|[A-Za-z0-9-_:.]+]}/files", middleware.TokenMiddleware(http.HandlerFunc(sda.Files))).Methods("GET")
+	r.Handle("/metadata/datasets/{dataset:https?://[^\\s/$.?#].[^\\s]+|[A-Za-z0-9-_:.]+}/files", middleware.TokenMiddleware(http.HandlerFunc(sda.Files))).Methods("GET")
 	r.Handle("/files/{fileid:[A-Za-z0-9-_:.]+}", middleware.TokenMiddleware(http.HandlerFunc(sda.Download))).Methods("GET")
 	r.HandleFunc("/health", healthResponse).Methods("GET")
 


### PR DESCRIPTION
EGA dataset ids were not matched with the current regex adjust it so that urls and EGA datasets are matched