### PR TITLE
update golangci-lint version to 1.44

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -16,5 +16,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: v1.42
+          version: v1.44
           args: -E gosec,goconst,nestif,bodyclose,rowserrcheck

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -43,6 +43,7 @@ func GetOIDCDetails(url string) (OIDCDetails, error) {
 		log.Errorf("failed to parse JSON response, %s", err)
 		return u, err
 	}
+	defer response.Body.Close()
 	log.Debugf("received OIDC config %s from %s", u, url)
 	return u, nil
 }


### PR DESCRIPTION
golangci-lint has a new version, updating to that and fixing issues.