### PR TITLE
make session cookie name configurable

### DIFF
--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -18,7 +18,7 @@ func TokenMiddleware(nextHandler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		// Check if dataset permissions are cached to session
-		sessionCookie, err := r.Cookie("sda_session_key")
+		sessionCookie, err := r.Cookie(config.Config.Session.Name)
 		if err != nil {
 			log.Debugf("no session cookie received")
 		}
@@ -59,7 +59,7 @@ func TokenMiddleware(nextHandler http.Handler) http.Handler {
 			key := session.NewSessionKey()
 			session.Set(key, datasets)
 			sessionCookie := &http.Cookie{
-				Name:     "sda_session_key",
+				Name:     config.Config.Session.Name,
 				Value:    key,
 				Domain:   config.Config.Session.Domain,
 				Secure:   config.Config.Session.Secure,

--- a/api/middleware/middleware_test.go
+++ b/api/middleware/middleware_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/neicnordic/sda-download/internal/config"
 	"github.com/neicnordic/sda-download/internal/session"
 	"github.com/neicnordic/sda-download/pkg/auth"
 )
@@ -205,7 +206,7 @@ func TestTokenMiddleware_Success_NoCache(t *testing.T) {
 	}
 	// nolint:bodyclose
 	for _, c := range w.Result().Cookies() {
-		if c.Name == "sda_session_key" {
+		if c.Name == config.Config.Session.Name {
 			if c.Value != expectedSessionKey {
 				t.Errorf("TestTokenMiddleware_Success_NoCache failed, got %s expected %s", c.Value, expectedSessionKey)
 			}
@@ -262,7 +263,7 @@ func TestTokenMiddleware_Success_FromCache(t *testing.T) {
 	}
 	// nolint:bodyclose
 	for _, c := range w.Result().Cookies() {
-		if c.Name == "sda_session_key" {
+		if c.Name == config.Config.Session.Name {
 			t.Errorf("TestTokenMiddleware_Success_FromCache failed, got a session cookie, when should not have")
 		}
 	}

--- a/dev_utils/config.yaml
+++ b/dev_utils/config.yaml
@@ -35,6 +35,9 @@ session:
   # session cookie HttpOnly value, if true, TLS must be active
   # default value = true
   httponly: true
+  # name of session cookie
+  # default value = sda_session_key
+  name: "sda_session_key"
 
 c4gh:
   passphrase: "oaagCP1YgAZeEyl2eJAkHv9lkcWXWFgm"

--- a/docs/API.md
+++ b/docs/API.md
@@ -4,7 +4,7 @@ All endpoints require an `Authorization` header with an access token in the `Bea
 Authorization: Bearer <token>
 ```
 ### Authenticated Session
-The client can establish a session to skip time-costly visa validations for further requests. Session is based on the `sda_session_key` cookie returned by the server, which should be returned in later requests.
+The client can establish a session to skip time-costly visa validations for further requests. Session is based on the `SESSION_NAME=sda_session_key` (configurable name) cookie returned by the server, which should be returned in later requests.
 ## Datasets
 The `/metadata/datasets` endpoint is used to display the list of datasets the given token is authorised to access, that are present in the archive.
 ### Request

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,6 +72,10 @@ type SessionConfig struct {
 	// Cookie HTTPOnly value. If true, cookie can't be read by JavaScript.
 	// Optional. Default value true
 	HTTPOnly bool
+
+	// Name of session cookie.
+	// Optional. Default value sda_session_key
+	Name string
 }
 
 type TrustedISS struct {
@@ -214,6 +218,7 @@ func (c *ConfigMap) applyDefaults() {
 	viper.SetDefault("session.secure", true)
 	viper.SetDefault("session.httponly", true)
 	viper.SetDefault("log.level", "info")
+	viper.SetDefault("session.name", "sda_session_key")
 }
 
 // configS3Storage populates and returns a S3Conf from the
@@ -312,6 +317,7 @@ func (c *ConfigMap) sessionConfig() {
 	c.Session.Domain = viper.GetString("session.domain")
 	c.Session.Secure = viper.GetBool("session.secure")
 	c.Session.HTTPOnly = viper.GetBool("session.httponly")
+	c.Session.Name = viper.GetString("session.name")
 }
 
 // configDatabase provides configuration for the database


### PR DESCRIPTION
### Added
- new configuration variable viper=`session.name` or env=`SESSION_NAME` to manage name of the session cookie