### PR TITLE
Feature/no datasets no error

### DIFF
--- a/.github/integration/tests/common/50_check_endpoint.sh
+++ b/.github/integration/tests/common/50_check_endpoint.sh
@@ -99,8 +99,8 @@ token=$(curl --cacert certs/ca.pem "https://localhost:8000/tokens" | jq -r  '.[1
 
 check_empty_token=$(curl -o /dev/null -s -w "%{http_code}\n" -X GET -I --cacert certs/ca.pem -H "Authorization: Bearer $token" https://localhost:8443/metadata/datasets)
 
-if [ "$check_empty_token" != "404" ]; then
-    echo "response for empty token is not 404"
+if [ "$check_empty_token" != "200" ]; then
+    echo "response for empty token is not 200"
     echo "got: ${check_empty_token}"
     exit 1
 fi
@@ -117,8 +117,8 @@ token=$(curl --cacert certs/ca.pem "https://localhost:8000/tokens" | jq -r  '.[2
 
 check_empty_token=$(curl -o /dev/null -s -w "%{http_code}\n" -X GET -I --cacert certs/ca.pem -H "Authorization: Bearer $token" https://localhost:8443/metadata/datasets)
 
-if [ "$check_empty_token" != "404" ]; then
-    echo "response for token with untrusted sources is not 404"
+if [ "$check_empty_token" != "200" ]; then
+    echo "response for token with untrusted sources is not 200"
     echo "got: ${check_empty_token}"
     exit 1
 fi

--- a/.github/integration/tests/s3notls/52_check_endpoint.sh
+++ b/.github/integration/tests/s3notls/52_check_endpoint.sh
@@ -95,8 +95,8 @@ token=$(curl --cacert certs/ca.pem "https://localhost:8000/tokens" | jq -r  '.[1
 
 check_empty_token=$(curl -o /dev/null -s -w "%{http_code}\n" -H "Authorization: Bearer $token" http://localhost:8080/metadata/datasets)
 
-if [ "$check_empty_token" != "404" ]; then
-    echo "response for empty token is not 404"
+if [ "$check_empty_token" != "200" ]; then
+    echo "response for empty token is not 200"
     echo "got: ${check_empty_token}"
     exit 1
 fi

--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -48,12 +48,11 @@ func TokenMiddleware(nextHandler http.Handler) http.Handler {
 			}
 
 			// Get permissions
+			// This used to cause a "404 no datasets found", but now the error has been moved deeper:
+			// 200 OK with [] empty dataset list, when listing datasets (use case for sda-filesystem download tool)
+			// 404 dataset not found, when listing files from a dataset
+			// 401 unauthorised, when downloading a file
 			datasets = auth.GetPermissions(*visas)
-			if len(datasets) == 0 {
-				log.Debug("token carries no dataset permissions matching the database")
-				http.Error(w, "no datasets found", 404)
-				return
-			}
 
 			// Start a new session and store datasets under the session key
 			key := session.NewSessionKey()

--- a/api/middleware/middleware_test.go
+++ b/api/middleware/middleware_test.go
@@ -134,18 +134,10 @@ func TestTokenMiddleware_Fail_GetPermissions(t *testing.T) {
 	// Test the outcomes of the handler
 	response := w.Result()
 	defer response.Body.Close()
-	body, _ := io.ReadAll(response.Body)
-	expectedStatusCode := 404
-	expectedBody := []byte("no datasets found\n")
+	expectedStatusCode := 200
 
 	if response.StatusCode != expectedStatusCode {
 		t.Errorf("TestTokenMiddleware_Fail_GetPermissions failed, got %d expected %d", response.StatusCode, expectedStatusCode)
-	}
-	if !bytes.Equal(body, []byte(expectedBody)) {
-		// visual byte comparison in terminal (easier to find string differences)
-		t.Error(body)
-		t.Error([]byte(expectedBody))
-		t.Errorf("TestTokenMiddleware_Fail_GetPermissions failed, got %s expected %s", string(body), string(expectedBody))
 	}
 
 	// Return mock functions to originals

--- a/dev_utils/run_integration_test.sh
+++ b/dev_utils/run_integration_test.sh
@@ -134,8 +134,8 @@ token=$(curl --cacert certs/ca.pem "https://localhost:8000/tokens" | jq -r  '.[1
 
 check_empty_token=$(curl -o /dev/null -s -w "%{http_code}\n" -X GET -I --cacert certs/ca.pem -H "Authorization: Bearer $token" https://localhost:8443/metadata/datasets)
 
-if [ "$check_empty_token" != "404" ]; then
-    echo "response for empty token is not 404"
+if [ "$check_empty_token" != "200" ]; then
+    echo "response for empty token is not 200"
     echo "got: ${check_empty_token}"
     exit 1
 fi

--- a/dev_utils/run_integration_test_no_tls.sh
+++ b/dev_utils/run_integration_test_no_tls.sh
@@ -136,8 +136,8 @@ token=$(curl --cacert certs/ca.pem "https://localhost:8000/tokens" | jq -r  '.[1
 
 check_empty_token=$(curl -o /dev/null -s -w "%{http_code}\n" -H "Authorization: Bearer $token" http://localhost:8080/metadata/datasets)
 
-if [ "$check_empty_token" != "404" ]; then
-    echo "response for empty token is not 404"
+if [ "$check_empty_token" != "200" ]; then
+    echo "response for empty token is not 200"
     echo "got: ${check_empty_token}"
     exit 1
 fi

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -151,7 +151,7 @@ var GetVisas = func(o OIDCDetails, token string) (*Visas, error) {
 // GetPermissions parses visas and finds matching dataset names from the database, returning a list of matches
 var GetPermissions = func(visas Visas) []string {
 	log.Debug("parsing permissions from visas")
-	var datasets []string
+	datasets := []string{} // default empty array
 
 	log.Debugf("number of visas to check: %d", len(visas.Visa))
 


### PR DESCRIPTION
This functionality stems from a need for supporting multiple data archives in https://github.com/CSCfi/sda-filesystem and this method makes the login functionality smoother, when it's not an error, but a passed authentication with 0 permissions, when the user authentication passes, but they have no visas that match the current database.

### Old functionality
- if user passes authentication, but has no dataset permissions, they would get `404 no datasets found` from all endpoints

### New functionality
- if user passes authentication, but has no dataset permissions, they get:
  - `GET /metadata/datasets` responds `[]` empty dataset list with `200 HTTP OK`, no error, authentication passed, but user has no permissions
  - `GET /metadata/datasets/{dataset}/files` responds `404 dataset not found` when trying to list files from a dataset they don't have access to (refers to both dataset not found in user permissions or dataset not found in archive)
  - `GET /files/{fileId}` responds `401 unauthorised` when trying to download a file they don't have access to 