### PR TITLE
add optional scheme param to dataset/files endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -26,7 +26,7 @@ func Setup() *http.Server {
 	r := mux.NewRouter().SkipClean(true)
 
 	r.Handle("/metadata/datasets", middleware.TokenMiddleware(http.HandlerFunc(sda.Datasets))).Methods("GET")
-	r.Handle("/metadata/datasets/{dataset:https?://[^\\s/$.?#].[^\\s]+|[A-Za-z0-9-_:.]+}/files", middleware.TokenMiddleware(http.HandlerFunc(sda.Files))).Methods("GET")
+	r.Handle("/metadata/datasets/{dataset:[^\\s/$.?#].[^\\s]+|[A-Za-z0-9-_:.]+}/files", middleware.TokenMiddleware(http.HandlerFunc(sda.Files))).Methods("GET")
 	r.Handle("/files/{fileid:[A-Za-z0-9-_:.]+}", middleware.TokenMiddleware(http.HandlerFunc(sda.Download))).Methods("GET")
 	r.HandleFunc("/health", healthResponse).Methods("GET")
 

--- a/api/sda/sda.go
+++ b/api/sda/sda.go
@@ -92,9 +92,9 @@ func Files(w http.ResponseWriter, r *http.Request) {
 	// if there was a scheme (e.g. DOI)
 	scheme := r.URL.Query().Get("scheme")
 	if scheme != "" {
-		log.Debugf("adding scheme=%s to dataset=%s", scheme, dataset)
+		log.Debugf("adding scheme=%s to dataset=%s", sanitizeString(scheme), sanitizeString(dataset))
 		dataset = fmt.Sprintf("%s://%s", scheme, dataset)
-		log.Debugf("new dataset=%s", dataset)
+		log.Debugf("new dataset=%s", sanitizeString(dataset))
 	}
 
 	// Get dataset files

--- a/api/sda/sda.go
+++ b/api/sda/sda.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"regexp"
@@ -82,6 +83,19 @@ func Files(w http.ResponseWriter, r *http.Request) {
 
 	vars := mux.Vars(r)
 	dataset := vars["dataset"]
+
+	// Get optional dataset scheme
+	// A scheme can be delivered separately in a query parameter
+	// as schemes may sometimes be problematic when they travel
+	// in the path. A client can conveniently split the scheme with "://"
+	// which results in 1 item if there is no scheme (e.g. EGAD) or 2 items
+	// if there was a scheme (e.g. DOI)
+	scheme := r.URL.Query().Get("scheme")
+	if scheme != "" {
+		log.Debugf("adding scheme=%s to dataset=%s", scheme, dataset)
+		dataset = fmt.Sprintf("%s://%s", scheme, dataset)
+		log.Debugf("new dataset=%s", dataset)
+	}
 
 	// Get dataset files
 	files, code, err := getFiles(dataset, r.Context())

--- a/api/sda/sda.go
+++ b/api/sda/sda.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/elixir-oslo/crypt4gh/model/headers"
 	"github.com/elixir-oslo/crypt4gh/streaming"
@@ -91,10 +92,15 @@ func Files(w http.ResponseWriter, r *http.Request) {
 	// which results in 1 item if there is no scheme (e.g. EGAD) or 2 items
 	// if there was a scheme (e.g. DOI)
 	scheme := r.URL.Query().Get("scheme")
+	schemeLogs := strings.Replace(scheme, "\n", "", -1)
+	schemeLogs = strings.Replace(schemeLogs, "\r", "", -1)
+
+	datasetLogs := strings.Replace(dataset, "\n", "", -1)
+	datasetLogs = strings.Replace(datasetLogs, "\r", "", -1)
 	if scheme != "" {
-		log.Debugf("adding scheme=%s to dataset=%s", sanitizeString(scheme), sanitizeString(dataset))
+		log.Debugf("adding scheme=%s to dataset=%s", schemeLogs, datasetLogs)
 		dataset = fmt.Sprintf("%s://%s", scheme, dataset)
-		log.Debugf("new dataset=%s", sanitizeString(dataset))
+		log.Debugf("new dataset=%s", datasetLogs)
 	}
 
 	// Get dataset files

--- a/dev_utils/run_integration_test.sh
+++ b/dev_utils/run_integration_test.sh
@@ -96,9 +96,23 @@ fi
 
 echo "expected dataset found"
 
-## Test datasets/files endpoint 
+## Test datasets/files endpoint, no scheme
+## dataset=https://doi.example/ty009.sfrrss/600.45asasga
 
 check_files=$(curl --cacert certs/ca.pem -H "Authorization: Bearer $token" "https://localhost:8443/metadata/datasets/https://doi.example/ty009.sfrrss/600.45asasga/files" | jq -r '.[0].fileId')
+
+if [ "$check_files" != "urn:neic:001-002" ]; then
+    echo "file with id urn:neic:001-002 not found"
+    echo "got: ${check_files}"
+    exit 1
+fi
+
+echo "expected file found"
+
+## Test datasets/files endpoint, with scheme param (scheme separated from dataset)
+## dataset=doi.example/ty009.sfrrss/600.45asasga, scheme=https
+
+check_files=$(curl --cacert certs/ca.pem -H "Authorization: Bearer $token" "https://localhost:8443/metadata/datasets/doi.example/ty009.sfrrss/600.45asasga/files?scheme=https" | jq -r '.[0].fileId')
 
 if [ "$check_files" != "urn:neic:001-002" ]; then
     echo "file with id urn:neic:001-002 not found"

--- a/docs/API.md
+++ b/docs/API.md
@@ -24,6 +24,22 @@ Files contained by a dataset are listed using the `datasetName` from `/metadata/
 ```
 GET /metadata/datasets/{datasetName}/files
 ```
+#### Scheme Parameter
+The `?scheme=` query parameter is optional. When a dataset contains a scheme, it may sometimes be problematic with reverse proxies.
+The scheme can be split from the dataset name, and supplied in a query parameter.
+```
+dataset := strings.Split("https://doi.org/abc/123", "://")
+len(dataset) // 2 -> scheme can be used
+dataset[0] // "https"
+dataset[1] // "doi.org/abc/123
+
+dataset := strings.Split("EGAD1000", "://")
+len(dataset) // 1 -> no scheme
+dataset[0] // "EGAD1000"
+```
+```
+GET /metadata/datasets/{datasetName}/files?scheme=https
+```
 ### Response
 ```
 [


### PR DESCRIPTION
### Changes
- new optional query parameter `scheme` to `/metadata/datasets/{datasetId}/files` endpoint

### Rationale
GA4GH visa values are URLs, and when using visas for dataset permissions (dataset IDs), it places URL in URL path, which is not a good practice (it breaks in some cases of reverse proxying). This change introduces a backward compatible solution to pass URL dataset IDs where the scheme is split and added as a query param.

Client software can check if they should use `scheme` by splitting the dataset ID with `://`
```
dataset := strings.Split("https://doi.org/abc/123", "://")
len(dataset) // 2 -> scheme can be used
dataset[0] // "https"
dataset[1] // "doi.org/abc/123

dataset := strings.Split("EGAD1000", "://")
len(dataset) // 1 -> no scheme
dataset[0] // "EGAD1000"
```
Example requests
```
https://sda-download.org/metadata/datasets/https://doi.org/abc/123/files
# dataset = https://doi.org/abc/123

https://sda-download.org/metadata/datasets/doi.org/abc/123/files?scheme=https
# dataset = https://doi.org/abc/123

https://sda-download.org/metadata/datasets/EGAD1000/files
# dataset = EGAD1000
```

### Testing
- [x] manual testing
- [x] integration testing