### PR TITLE
Refactor with more restrictive linting

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -25,4 +25,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3.3.1
         with:
           version: v1.50
-          args: -E gosec,goconst,nestif,bodyclose,rowserrcheck
+          args: -E bodyclose,gocritic,gofmt,gosec,govet,nestif,nlreturn,revive,rowserrcheck --exclude G401,G501,G107

--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -36,6 +36,7 @@ func TokenMiddleware(nextHandler http.Handler) http.Handler {
 			token, code, err := auth.GetToken(r.Header.Get("Authorization"))
 			if err != nil {
 				http.Error(w, err.Error(), code)
+
 				return
 			}
 
@@ -44,6 +45,7 @@ func TokenMiddleware(nextHandler http.Handler) http.Handler {
 			if err != nil {
 				log.Debug("failed to validate token at AAI")
 				http.Error(w, "bad token", 401)
+
 				return
 			}
 
@@ -83,8 +85,8 @@ func TokenMiddleware(nextHandler http.Handler) http.Handler {
 // storeDatasets stores the dataset list to the request context
 func storeDatasets(ctx context.Context, datasets []string) context.Context {
 	log.Debugf("storing %v datasets to request context", datasets)
-	// nolint:staticcheck
-	return context.WithValue(ctx, "datasets", datasets)
+
+	return context.WithValue(ctx, "datasets", datasets) // nolint:staticcheck
 }
 
 // GetDatasets extracts the dataset list from the request context
@@ -92,8 +94,10 @@ var GetDatasets = func(ctx context.Context) []string {
 	datasets := ctx.Value("datasets")
 	if datasets == nil {
 		log.Debug("request datasets context is empty")
+
 		return []string{}
 	}
 	log.Debugf("returning %v from request context", datasets)
+
 	return datasets.([]string)
 }

--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -10,6 +10,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+type datasetsKey string
+
 // TokenMiddleware performs access token verification and validation
 // JWTs are verified and validated by the app, opaque tokens are sent to AAI for verification
 // Successful auth results in list of authorised datasets
@@ -85,13 +87,16 @@ func TokenMiddleware(nextHandler http.Handler) http.Handler {
 // storeDatasets stores the dataset list to the request context
 func storeDatasets(ctx context.Context, datasets []string) context.Context {
 	log.Debugf("storing %v datasets to request context", datasets)
+	// as specified in docs: https://pkg.go.dev/context#WithValue
+	k := datasetsKey("datasets")
+	ctx = context.WithValue(ctx, k, datasets)
 
-	return context.WithValue(ctx, "datasets", datasets) // nolint:staticcheck
+	return ctx
 }
 
 // GetDatasets extracts the dataset list from the request context
 var GetDatasets = func(ctx context.Context) []string {
-	datasets := ctx.Value("datasets")
+	datasets := ctx.Value(datasetsKey("datasets"))
 	if datasets == nil {
 		log.Debug("request datasets context is empty")
 

--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -10,7 +10,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type datasetsKey string
+type stringVariable string
+
+// as specified in docs: https://pkg.go.dev/context#WithValue
+var datasetsKey = stringVariable("datasets")
 
 // TokenMiddleware performs access token verification and validation
 // JWTs are verified and validated by the app, opaque tokens are sent to AAI for verification
@@ -87,16 +90,15 @@ func TokenMiddleware(nextHandler http.Handler) http.Handler {
 // storeDatasets stores the dataset list to the request context
 func storeDatasets(ctx context.Context, datasets []string) context.Context {
 	log.Debugf("storing %v datasets to request context", datasets)
-	// as specified in docs: https://pkg.go.dev/context#WithValue
-	k := datasetsKey("datasets")
-	ctx = context.WithValue(ctx, k, datasets)
+
+	ctx = context.WithValue(ctx, datasetsKey, datasets)
 
 	return ctx
 }
 
 // GetDatasets extracts the dataset list from the request context
 var GetDatasets = func(ctx context.Context) []string {
-	datasets := ctx.Value(datasetsKey("datasets"))
+	datasets := ctx.Value(datasetsKey)
 	if datasets == nil {
 		log.Debug("request datasets context is empty")
 

--- a/api/middleware/middleware_test.go
+++ b/api/middleware/middleware_test.go
@@ -169,8 +169,6 @@ func TestTokenMiddleware_Success_NoCache(t *testing.T) {
 		return "key"
 	}
 
-	k := datasetsKey("datasets")
-
 	// Mock request and response holders
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "https://testing.fi", nil)
@@ -178,7 +176,7 @@ func TestTokenMiddleware_Success_NoCache(t *testing.T) {
 	// Now that we are modifying the request context, we need to place the context test inside the handler
 	expectedDatasets := []string{"dataset1", "dataset2"}
 	testEndpointWithContextData := func(w http.ResponseWriter, r *http.Request) {
-		datasets := r.Context().Value(k).([]string)
+		datasets := r.Context().Value(datasetsKey).([]string)
 		// string arrays can't be compared
 		if strings.Join(datasets, "") == strings.Join(expectedDatasets, "")+"\n" {
 			t.Errorf("TestTokenMiddleware_Success_NoCache failed, got %s expected %s", datasets, expectedDatasets)
@@ -233,12 +231,10 @@ func TestTokenMiddleware_Success_FromCache(t *testing.T) {
 		Value: "key",
 	})
 
-	k := datasetsKey("datasets")
-
 	// Now that we are modifying the request context, we need to place the context test inside the handler
 	expectedDatasets := []string{"dataset1", "dataset2"}
 	testEndpointWithContextData := func(w http.ResponseWriter, r *http.Request) {
-		datasets := r.Context().Value(k).([]string)
+		datasets := r.Context().Value(datasetsKey).([]string)
 		// string arrays can't be compared
 		if strings.Join(datasets, "") == strings.Join(expectedDatasets, "")+"\n" {
 			t.Errorf("TestTokenMiddleware_Success_FromCache failed, got %s expected %s", datasets, expectedDatasets)
@@ -279,7 +275,7 @@ func TestStoreDatasets(t *testing.T) {
 	modifiedContext := storeDatasets(r.Context(), datasets)
 
 	// Verify that context has new data
-	storedDatasets := modifiedContext.Value(datasetsKey("datasets")).([]string)
+	storedDatasets := modifiedContext.Value(datasetsKey).([]string)
 	// string arrays can't be compared
 	if strings.Join(datasets, "") != strings.Join(storedDatasets, "") {
 		t.Errorf("TestStoreDatasets failed, got %s, expected %s", storedDatasets, datasets)

--- a/api/middleware/middleware_test.go
+++ b/api/middleware/middleware_test.go
@@ -169,6 +169,8 @@ func TestTokenMiddleware_Success_NoCache(t *testing.T) {
 		return "key"
 	}
 
+	k := datasetsKey("datasets")
+
 	// Mock request and response holders
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "https://testing.fi", nil)
@@ -176,7 +178,7 @@ func TestTokenMiddleware_Success_NoCache(t *testing.T) {
 	// Now that we are modifying the request context, we need to place the context test inside the handler
 	expectedDatasets := []string{"dataset1", "dataset2"}
 	testEndpointWithContextData := func(w http.ResponseWriter, r *http.Request) {
-		datasets := r.Context().Value("datasets").([]string)
+		datasets := r.Context().Value(k).([]string)
 		// string arrays can't be compared
 		if strings.Join(datasets, "") == strings.Join(expectedDatasets, "")+"\n" {
 			t.Errorf("TestTokenMiddleware_Success_NoCache failed, got %s expected %s", datasets, expectedDatasets)
@@ -231,10 +233,12 @@ func TestTokenMiddleware_Success_FromCache(t *testing.T) {
 		Value: "key",
 	})
 
+	k := datasetsKey("datasets")
+
 	// Now that we are modifying the request context, we need to place the context test inside the handler
 	expectedDatasets := []string{"dataset1", "dataset2"}
 	testEndpointWithContextData := func(w http.ResponseWriter, r *http.Request) {
-		datasets := r.Context().Value("datasets").([]string)
+		datasets := r.Context().Value(k).([]string)
 		// string arrays can't be compared
 		if strings.Join(datasets, "") == strings.Join(expectedDatasets, "")+"\n" {
 			t.Errorf("TestTokenMiddleware_Success_FromCache failed, got %s expected %s", datasets, expectedDatasets)
@@ -275,7 +279,7 @@ func TestStoreDatasets(t *testing.T) {
 	modifiedContext := storeDatasets(r.Context(), datasets)
 
 	// Verify that context has new data
-	storedDatasets := modifiedContext.Value("datasets").([]string)
+	storedDatasets := modifiedContext.Value(datasetsKey("datasets")).([]string)
 	// string arrays can't be compared
 	if strings.Join(datasets, "") != strings.Join(storedDatasets, "") {
 		t.Errorf("TestStoreDatasets failed, got %s, expected %s", storedDatasets, datasets)

--- a/api/sda/sda.go
+++ b/api/sda/sda.go
@@ -96,11 +96,11 @@ func Files(w http.ResponseWriter, r *http.Request) {
 	// which results in 1 item if there is no scheme (e.g. EGAD) or 2 items
 	// if there was a scheme (e.g. DOI)
 	scheme := r.URL.Query().Get("scheme")
-	schemeLogs := strings.Replace(scheme, "\n", "", -1)
-	schemeLogs = strings.Replace(schemeLogs, "\r", "", -1)
+	schemeLogs := strings.ReplaceAll(scheme, "\n", "")
+	schemeLogs = strings.ReplaceAll(schemeLogs, "\r", "")
 
-	datasetLogs := strings.Replace(dataset, "\n", "", -1)
-	datasetLogs = strings.Replace(datasetLogs, "\r", "", -1)
+	datasetLogs := strings.ReplaceAll(dataset, "\n", "")
+	datasetLogs = strings.ReplaceAll(datasetLogs, "\r", "")
 	if scheme != "" {
 		log.Debugf("adding scheme=%s to dataset=%s", schemeLogs, datasetLogs)
 		dataset = fmt.Sprintf("%s://%s", scheme, dataset)

--- a/api/sda/sda_test.go
+++ b/api/sda/sda_test.go
@@ -173,6 +173,7 @@ func TestGetFiles_Success(t *testing.T) {
 		}
 		files := []*database.FileInfo{}
 		files = append(files, &fileInfo)
+
 		return files, nil
 	}
 
@@ -256,6 +257,7 @@ func TestFiles_Success(t *testing.T) {
 		}
 		files := []*database.FileInfo{}
 		files = append(files, &fileInfo)
+
 		return files, 200, nil
 	}
 
@@ -534,6 +536,7 @@ func TestDownload_Fail_OpenFile(t *testing.T) {
 			ArchiveSize: 0,
 			Header:      []byte{},
 		}
+
 		return fileDetails, nil
 	}
 
@@ -589,6 +592,7 @@ func TestDownload_Fail_ParseCoordinates(t *testing.T) {
 			ArchiveSize: 0,
 			Header:      []byte{},
 		}
+
 		return fileDetails, nil
 	}
 	parseCoordinates = func(r *http.Request) (*headers.DataEditListHeaderPacket, error) {
@@ -649,6 +653,7 @@ func TestDownload_Fail_StreamFile(t *testing.T) {
 			ArchiveSize: 0,
 			Header:      []byte{},
 		}
+
 		return fileDetails, nil
 	}
 	parseCoordinates = func(r *http.Request) (*headers.DataEditListHeaderPacket, error) {
@@ -714,6 +719,7 @@ func TestDownload_Success(t *testing.T) {
 			ArchiveSize: 0,
 			Header:      []byte{},
 		}
+
 		return fileDetails, nil
 	}
 	parseCoordinates = func(r *http.Request) (*headers.DataEditListHeaderPacket, error) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,7 +20,6 @@ func init() {
 	conf, err := config.NewConfig()
 	if err != nil {
 		log.Panicf("configuration loading failed, reason: %v", err)
-		panic(err)
 	}
 	config.Config = *conf
 
@@ -28,7 +27,6 @@ func init() {
 	db, err := database.NewDB(conf.DB)
 	if err != nil {
 		log.Panicf("database connection failed, reason: %v", err)
-		panic(err)
 	}
 	defer db.Close()
 	database.DB = db
@@ -37,7 +35,6 @@ func init() {
 	client, err := request.InitialiseClient()
 	if err != nil {
 		log.Panicf("http client init failed, reason: %v", err)
-		panic(err)
 	}
 	request.Client = client
 
@@ -46,7 +43,6 @@ func init() {
 	log.Info("retrieving OIDC configuration")
 	if err != nil {
 		log.Panicf("oidc init failed, reason: %v", err)
-		panic(err)
 	}
 	auth.Details = details
 	log.Info("OIDC configuration retrieved")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,7 +19,7 @@ func init() {
 	// Load configuration
 	conf, err := config.NewConfig()
 	if err != nil {
-		log.Fatalf("configuration loading failed, reason: %v", err)
+		log.Panicf("configuration loading failed, reason: %v", err)
 		panic(err)
 	}
 	config.Config = *conf
@@ -27,7 +27,7 @@ func init() {
 	// Connect to database
 	db, err := database.NewDB(conf.DB)
 	if err != nil {
-		log.Fatalf("database connection failed, reason: %v", err)
+		log.Panicf("database connection failed, reason: %v", err)
 		panic(err)
 	}
 	defer db.Close()
@@ -36,7 +36,7 @@ func init() {
 	// Initialise HTTP client for making requests
 	client, err := request.InitialiseClient()
 	if err != nil {
-		log.Fatalf("http client init failed, reason: %v", err)
+		log.Panicf("http client init failed, reason: %v", err)
 		panic(err)
 	}
 	request.Client = client
@@ -45,7 +45,7 @@ func init() {
 	details, err := auth.GetOIDCDetails(conf.OIDC.ConfigurationURL)
 	log.Info("retrieving OIDC configuration")
 	if err != nil {
-		log.Fatalf("oidc init failed, reason: %v", err)
+		log.Panicf("oidc init failed, reason: %v", err)
 		panic(err)
 	}
 	auth.Details = details
@@ -54,13 +54,13 @@ func init() {
 	// Initialise session cache
 	sessionCache, err := session.InitialiseSessionCache()
 	if err != nil {
-		log.Fatalf("session cache init failed, reason: %v", err)
+		log.Panicf("session cache init failed, reason: %v", err)
 	}
 	session.SessionCache = sessionCache
 
 	backend, err := storage.NewBackend(conf.Archive)
 	if err != nil {
-		log.Fatalf("Error initiating storage backend, reason: %v", err)
+		log.Panicf("Error initiating storage backend, reason: %v", err)
 	}
 	sda.Backend = backend
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -307,6 +307,7 @@ func (c *ConfigMap) appConfig() error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -357,6 +358,7 @@ func (c *ConfigMap) configDatabase() error {
 		db.CACert = viper.GetString("db.cacert")
 	}
 	c.DB = db
+
 	return nil
 }
 
@@ -366,6 +368,7 @@ func readTrustedIssuers(filePath string) ([]TrustedISS, error) {
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		log.Errorf("Error when opening file with issuers, reason: %v", err)
+
 		return nil, err
 	}
 
@@ -374,6 +377,7 @@ func readTrustedIssuers(filePath string) ([]TrustedISS, error) {
 	err = json.Unmarshal(content, &payload)
 	if err != nil {
 		log.Errorf("Error during Unmarshal, reason: %v", err)
+
 		return nil, err
 	}
 
@@ -390,6 +394,7 @@ func constructWhitelist(obj []TrustedISS) *jwk.MapWhitelist {
 			wl.Add(value.JKU)
 		}
 	}
+
 	return wl
 }
 
@@ -412,5 +417,6 @@ func GetC4GHKey() (*[32]byte, error) {
 
 	keyFile.Close()
 	log.Info("crypt4gh private key loaded")
+
 	return &key, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,10 +20,10 @@ const POSIX = "posix"
 const S3 = "s3"
 
 // Config is a global configuration value store
-var Config ConfigMap
+var Config Map
 
 // ConfigMap stores all different configs
-type ConfigMap struct {
+type Map struct {
 	App     AppConfig
 	Session SessionConfig
 	DB      DatabaseConfig
@@ -130,7 +130,7 @@ type DatabaseConfig struct {
 }
 
 // NewConfig populates ConfigMap with data
-func NewConfig() (*ConfigMap, error) {
+func NewConfig() (*Map, error) {
 	viper.SetConfigName("config")
 	viper.AddConfigPath(".")
 	viper.AutomaticEnv()
@@ -187,7 +187,7 @@ func NewConfig() (*ConfigMap, error) {
 		log.Printf("Setting log level to '%s'", stringLevel)
 	}
 
-	c := &ConfigMap{}
+	c := &Map{}
 	c.applyDefaults()
 	c.sessionConfig()
 	c.configArchive()
@@ -210,7 +210,7 @@ func NewConfig() (*ConfigMap, error) {
 
 // applyDefaults set default values for web server and session
 // default to host 0.0.0.0 as it will the main way we deploy this application
-func (c *ConfigMap) applyDefaults() {
+func (c *Map) applyDefaults() {
 	viper.SetDefault("app.host", "0.0.0.0")
 	viper.SetDefault("app.port", 8080)
 	viper.SetDefault("session.expiration", -1)
@@ -255,7 +255,7 @@ func configS3Storage(prefix string) storage.S3Conf {
 	return s3
 }
 
-func (c *ConfigMap) configureOIDC() error {
+func (c *Map) configureOIDC() error {
 	c.OIDC.ConfigurationURL = viper.GetString("oidc.configuration.url")
 	c.OIDC.Whitelist = nil
 	c.OIDC.TrustedList = nil
@@ -276,7 +276,7 @@ func (c *ConfigMap) configureOIDC() error {
 
 // configArchive provides configuration for the archive storage
 // we default to POSIX unless S3 specified
-func (c *ConfigMap) configArchive() {
+func (c *Map) configArchive() {
 	if viper.GetString("archive.type") == S3 {
 		c.Archive.Type = S3
 		c.Archive.S3 = configS3Storage("archive")
@@ -287,7 +287,7 @@ func (c *ConfigMap) configArchive() {
 }
 
 // appConfig sets required settings
-func (c *ConfigMap) appConfig() error {
+func (c *Map) appConfig() error {
 	c.App.Host = viper.GetString("app.host")
 	c.App.Port = viper.GetInt("app.port")
 	c.App.ServerCert = viper.GetString("app.servercert")
@@ -295,11 +295,8 @@ func (c *ConfigMap) appConfig() error {
 
 	if c.App.Port != 443 && c.App.Port != 8080 {
 		c.App.Port = viper.GetInt("app.port")
-	} else {
-		if c.App.ServerCert != "" && c.App.ServerKey != "" {
-			c.App.Port = 443
-		}
-
+	} else if c.App.ServerCert != "" && c.App.ServerKey != "" {
+		c.App.Port = 443
 	}
 
 	var err error
@@ -312,7 +309,7 @@ func (c *ConfigMap) appConfig() error {
 }
 
 // sessionConfig controls cookie settings and session cache
-func (c *ConfigMap) sessionConfig() {
+func (c *Map) sessionConfig() {
 	c.Session.Expiration = time.Duration(viper.GetInt("session.expiration")) * time.Second
 	c.Session.Domain = viper.GetString("session.domain")
 	c.Session.Secure = viper.GetBool("session.secure")
@@ -321,7 +318,7 @@ func (c *ConfigMap) sessionConfig() {
 }
 
 // configDatabase provides configuration for the database
-func (c *ConfigMap) configDatabase() error {
+func (c *Map) configDatabase() error {
 	db := DatabaseConfig{}
 
 	// defaults

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -72,7 +72,7 @@ func (suite *TestSuite) TestAppConfig() {
 
 	viper.Set("db.sslmode", "disable")
 
-	c := &ConfigMap{}
+	c := &Map{}
 	err := c.appConfig()
 	assert.Error(suite.T(), err, "Error expected")
 	assert.Nil(suite.T(), c.App.Crypt4GHKey)
@@ -80,7 +80,7 @@ func (suite *TestSuite) TestAppConfig() {
 	// Generate a Crypt4GH private key, so that ConfigMap.appConfig() doesn't fail
 	generateKeyForTest(suite)
 
-	c = &ConfigMap{}
+	c = &Map{}
 	err = c.appConfig()
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "test", c.App.Host)
@@ -93,7 +93,7 @@ func (suite *TestSuite) TestArchiveConfig() {
 	viper.Set("archive.type", POSIX)
 	viper.Set("archive.location", "/test")
 
-	c := &ConfigMap{}
+	c := &Map{}
 	c.configArchive()
 	assert.Equal(suite.T(), "/test", c.Archive.Posix.Location)
 
@@ -108,7 +108,7 @@ func (suite *TestSuite) TestSessionConfig() {
 
 	viper.Set("db.sslmode", "disable")
 
-	c := &ConfigMap{}
+	c := &Map{}
 	c.sessionConfig()
 	assert.Equal(suite.T(), time.Duration(3600*time.Second), c.Session.Expiration)
 	assert.Equal(suite.T(), "test", c.Session.Domain)
@@ -121,13 +121,13 @@ func (suite *TestSuite) TestDatabaseConfig() {
 
 	// Test error on missing SSL vars
 	viper.Set("db.sslmode", "verify-full")
-	c := &ConfigMap{}
+	c := &Map{}
 	err := c.configDatabase()
 	assert.Error(suite.T(), err, "Error expected")
 
 	// Test no error on SSL disabled
 	viper.Set("db.sslmode", "disable")
-	c = &ConfigMap{}
+	c = &Map{}
 	err = c.configDatabase()
 	assert.NoError(suite.T(), err)
 
@@ -142,7 +142,7 @@ func (suite *TestSuite) TestDatabaseConfig() {
 	viper.Set("db.clientkey", "test")
 	viper.Set("db.sslmode", "verify-full")
 
-	c = &ConfigMap{}
+	c = &Map{}
 	err = c.configDatabase()
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "test", c.DB.Host)
@@ -160,12 +160,12 @@ func (suite *TestSuite) TestOIDC() {
 
 	// Test wrong file
 	viper.Set("oidc.trusted.iss", "../../iss.json")
-	c := &ConfigMap{}
+	c := &Map{}
 	err := c.configureOIDC()
 	assert.Error(suite.T(), err, "Error expected")
 
 	viper.Set("oidc.trusted.iss", "../../dev_utils/iss.json")
-	c = &ConfigMap{}
+	c = &Map{}
 	err = c.configureOIDC()
 	assert.NoError(suite.T(), err)
 
@@ -177,7 +177,7 @@ func (suite *TestSuite) TestOIDC() {
 	trustedList := []TrustedISS([]TrustedISS{{ISS: "https://demo.example", JKU: "https://mockauth:8000/idp/profile/oidc/keyset"}, {ISS: "https://demo1.example", JKU: "https://mockauth:8000/idp/profile/oidc/keyset"}})
 
 	whitelist := jwk.NewMapWhitelist().Add("https://mockauth:8000/idp/profile/oidc/keyset")
-	c = &ConfigMap{}
+	c = &Map{}
 	err = c.configureOIDC()
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "test", c.OIDC.ConfigurationURL)

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -53,6 +53,7 @@ var logFatalf = log.Fatalf
 
 func sanitizeString(str string) string {
 	var pattern = regexp.MustCompile(`([A-Za-z0-9-_:.]+)`)
+
 	return pattern.ReplaceAllString(str, "[identifier]: $1")
 }
 
@@ -64,15 +65,18 @@ func NewDB(config config.DatabaseConfig) (*SQLdb, error) {
 	db, err := sqlOpen("postgres", connInfo)
 	if err != nil {
 		log.Errorf("failed to connect to database, %s", err)
+
 		return nil, err
 	}
 
 	if err = db.Ping(); err != nil {
 		log.Errorf("could not get response from database, %s", err)
+
 		return nil, err
 	}
 
 	log.Debug("database connection formed")
+
 	return &SQLdb{DB: db, ConnInfo: connInfo}, nil
 }
 
@@ -131,10 +135,13 @@ var GetFiles = func(datasetID string) ([]*FileInfo, error) {
 		r, err = DB.getFiles(datasetID)
 		if err != nil {
 			count++
+
 			continue
 		}
+
 		break
 	}
+
 	return r, err
 }
 
@@ -153,6 +160,7 @@ func (dbs *SQLdb) getFiles(datasetID string) ([]*FileInfo, error) {
 	rows, err := db.Query(query, datasetID)
 	if err != nil {
 		log.Error(err)
+
 		return nil, err
 	}
 	defer rows.Close()
@@ -166,6 +174,7 @@ func (dbs *SQLdb) getFiles(datasetID string) ([]*FileInfo, error) {
 			&fi.DecryptedFileSize, &fi.DecryptedFileChecksum, &fi.DecryptedFileChecksumType, &fi.Status)
 		if err != nil {
 			log.Error(err)
+
 			return nil, err
 		}
 
@@ -198,10 +207,13 @@ var CheckDataset = func(dataset string) (bool, error) {
 		r, err = DB.checkDataset(dataset)
 		if err != nil {
 			count++
+
 			continue
 		}
+
 		break
 	}
+
 	return r, err
 }
 
@@ -232,10 +244,13 @@ var CheckFilePermission = func(fileID string) (string, error) {
 		r, err = DB.checkFilePermission(fileID)
 		if err != nil {
 			count++
+
 			continue
 		}
+
 		break
 	}
+
 	return r, err
 }
 
@@ -251,6 +266,7 @@ func (dbs *SQLdb) checkFilePermission(fileID string) (string, error) {
 	var datasetName string
 	if err := db.QueryRow(query, fileID).Scan(&datasetName); err != nil {
 		log.Errorf("requested file with %s does not exist", sanitizeString(fileID))
+
 		return "", err
 	}
 
@@ -275,10 +291,13 @@ var GetFile = func(fileID string) (*FileDownload, error) {
 		r, err = DB.getFile(fileID)
 		if err != nil {
 			count++
+
 			continue
 		}
+
 		break
 	}
+
 	return r, err
 }
 
@@ -296,12 +315,14 @@ func (dbs *SQLdb) getFile(fileID string) (*FileDownload, error) {
 	err := db.QueryRow(query, fileID).Scan(&fd.ArchivePath, &fd.ArchiveSize, &hexString)
 	if err != nil {
 		log.Errorf("could not retrieve details for file %s, reason %s", sanitizeString(fileID), err)
+
 		return nil, err
 	}
 
 	fd.Header, err = hex.DecodeString(hexString)
 	if err != nil {
 		log.Errorf("could not decode file header for file %s, reason %s", sanitizeString(fileID), err)
+
 		return nil, err
 	}
 

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -189,6 +189,7 @@ func TestClose(t *testing.T) {
 
 		mock.ExpectClose()
 		testDb.Close()
+
 		return nil
 	})
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -41,9 +41,11 @@ func InitialiseSessionCache() (*ristretto.Cache, error) {
 	)
 	if err != nil {
 		log.Errorf("failed to create session cache, reason=%v", err)
+
 		return nil, err
 	}
 	log.Debug("session cache created")
+
 	return sessionCache, nil
 }
 
@@ -58,6 +60,7 @@ var Get = func(key string) ([]string, bool) {
 		cachedDatasets = nil
 	}
 	log.Debugf("cache response, exists=%t, datasets=%s", exists, cachedDatasets)
+
 	return cachedDatasets, exists
 }
 
@@ -90,5 +93,6 @@ var NewSessionKey = func() string {
 	}
 
 	log.Debug("new session key generated")
+
 	return sessionKey
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -80,6 +80,7 @@ func (pb *posixBackend) NewFileReader(filePath string) (io.ReadCloser, error) {
 	file, err := os.Open(filepath.Join(filepath.Clean(pb.Location), filePath))
 	if err != nil {
 		log.Error(err)
+
 		return nil, err
 	}
 
@@ -95,6 +96,7 @@ func (pb *posixBackend) NewFileWriter(filePath string) (io.WriteCloser, error) {
 	file, err := os.OpenFile(filepath.Join(filepath.Clean(pb.Location), filePath), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0640)
 	if err != nil {
 		log.Error(err)
+
 		return nil, err
 	}
 
@@ -110,6 +112,7 @@ func (pb *posixBackend) GetFileSize(filePath string) (int64, error) {
 	stat, err := os.Stat(filepath.Join(filepath.Clean(pb.Location), filePath))
 	if err != nil {
 		log.Error(err)
+
 		return 0, err
 	}
 
@@ -213,6 +216,7 @@ func (sb *s3Backend) NewFileReader(filePath string) (io.ReadCloser, error) {
 
 	if err != nil {
 		log.Error(err)
+
 		return nil, err
 	}
 
@@ -239,6 +243,7 @@ func (sb *s3Backend) NewFileWriter(filePath string) (io.WriteCloser, error) {
 			_ = reader.CloseWithError(err)
 		}
 	}()
+
 	return writer, nil
 }
 
@@ -272,6 +277,7 @@ func (sb *s3Backend) GetFileSize(filePath string) (int64, error) {
 
 	if err != nil {
 		log.Errorln(err)
+
 		return 0, err
 	}
 

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -52,7 +52,7 @@ var s3Creatable = "somename"
 var writeData = []byte("this is a test")
 
 var cleanupFilesBack [1000]string
-var cleanupFiles []string = cleanupFilesBack[0:0]
+var cleanupFiles = cleanupFilesBack[0:0]
 
 var testPosixConf = posixConf{
 	"/"}
@@ -68,6 +68,7 @@ func writeName() (name string, err error) {
 
 	// Add to cleanup
 	cleanupFiles = append(cleanupFiles, name)
+
 	return name, err
 }
 
@@ -127,6 +128,7 @@ func TestPosixBackend(t *testing.T) {
 	writable, err := writeName()
 	if err != nil {
 		t.Error("could not find a writable name, bailing out from test")
+
 		return
 	}
 
@@ -156,6 +158,7 @@ func TestPosixBackend(t *testing.T) {
 
 	if reader == nil {
 		t.Error("reader that should be usable is not, bailing out")
+
 		return
 	}
 
@@ -207,6 +210,7 @@ func setupFakeS3() (err error) {
 
 	if err != nil {
 		log.Error("Unexpected error while setting up fake s3")
+
 		return err
 	}
 
@@ -324,6 +328,7 @@ func TestS3Backend(t *testing.T) {
 
 	if reader == nil {
 		t.Error("reader that should be usable is not, bailing out")
+
 		return
 	}
 

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -59,6 +59,7 @@ func TestGetOIDCDetails_Fail_JSONDecode(t *testing.T) {
 			// Response headers
 			Header: make(http.Header),
 		}
+
 		return response, nil
 	}
 
@@ -98,6 +99,7 @@ func TestGetOIDCDetails_Success(t *testing.T) {
 			// Response headers
 			Header: make(http.Header),
 		}
+
 		return response, nil
 	}
 
@@ -252,6 +254,7 @@ func TestGetVisas_Fail_JSONDecode(t *testing.T) {
 			// Response headers
 			Header: make(http.Header),
 		}
+
 		return response, nil
 	}
 
@@ -288,6 +291,7 @@ func TestGetVisas_Success(t *testing.T) {
 			// Response headers
 			Header: make(http.Header),
 		}
+
 		return response, nil
 	}
 

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -24,6 +24,7 @@ func InitialiseClient() (*http.Client, error) {
 		caCert, err := os.ReadFile(config.Config.OIDC.CACert)
 		if err != nil {
 			log.Errorf("Reading certificate file failed: %v", err)
+
 			return nil, err
 		}
 		log.Debug("Added certificate")
@@ -43,6 +44,7 @@ func InitialiseClient() (*http.Client, error) {
 	client := &http.Client{
 		Timeout:   20 * time.Second,
 		Transport: t}
+
 	return client, nil
 }
 
@@ -86,6 +88,7 @@ var MakeRequest = func(method string, url string, headers map[string]string, bod
 	// Check StatusCode in case an error has happened downstream and not catched by the `err!=nil`
 	if response.StatusCode >= 400 {
 		err = errors.New(strconv.Itoa(response.StatusCode))
+
 		return nil, err
 	}
 

--- a/pkg/request/request_test.go
+++ b/pkg/request/request_test.go
@@ -95,6 +95,7 @@ func TestMakeRequest_Fail_StatusCode(t *testing.T) {
 			Method: "GET",
 			URL:    u,
 		}
+
 		return r, nil
 	}
 
@@ -142,6 +143,7 @@ func TestMakeRequest_Success(t *testing.T) {
 			Method: "GET",
 			URL:    u,
 		}
+
 		return r, nil
 	}
 


### PR DESCRIPTION
- proper use of context type withvalue
- type name will be used as config.ConfigMap
- make use of replaceall
- new line before return, continue and break
