### PR TITLE
Convert database queries to use the v2 schema #minor

### DIFF
--- a/.github/integration/setup/common/10_services.sh
+++ b/.github/integration/setup/common/10_services.sh
@@ -34,7 +34,7 @@ else
 
     # We need to leave the $tostart variable unquoted here since we want it to split
     # shellcheck disable=SC2086
-    docker-compose -f compose-sda.yml up -d $tostart
+    docker-compose -f compose.yml up -d $tostart
 
     for p in $tostart; do
         RETRY_TIMES=0
@@ -54,7 +54,7 @@ else
         done
     done
 
-    docker-compose -f compose-sda.yml up -d
+    docker-compose -f compose.yml up -d
 
     RETRY_TIMES=0
     until docker ps -f name="download" --format "{{.Status}}" | grep "Up"

--- a/.github/integration/setup/common/23_create_db_entries.sh
+++ b/.github/integration/setup/common/23_create_db_entries.sh
@@ -4,12 +4,82 @@ cd dev_utils || exit 1
 
 chmod 600 certs/client-key.pem
 
-docker run --rm --name client --network dev_utils_default -v "$PWD/certs:/certs" \
-	-e PGSSLCERT=/certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
-	neicnordic/pg-client:latest postgresql://postgres:rootpassword@db:5432/lega \
-	-t -c "INSERT INTO local_ega.main (id, stable_id, status, submission_file_path, submission_file_extension, submission_file_calculated_checksum, submission_file_calculated_checksum_type, submission_file_size, submission_user, archive_file_reference, archive_file_type, archive_file_size, archive_file_checksum, archive_file_checksum_type, decrypted_file_size, decrypted_file_checksum, decrypted_file_checksum_type, encryption_method, version, header, created_by, last_modified_by, created_at, last_modified) VALUES (1, 'urn:neic:001-002', 'READY', 'dummy_data.c4gh', 'c4gh', '5e9c767958cc3f6e8d16512b8b8dcab855ad1e04e05798b86f50ef600e137578', 'SHA256', NULL, 'test', '4293c9a7-dc50-46db-b79a-27ddc0dad1c6', NULL, 1049081, '74820dbcf9d30f8ccd1ea59c17d5ec8a714aabc065ae04e46ad82fcf300a731e', 'SHA256', 1048605, '06bb0a514b26497b4b41b30c547ad51d059d57fb7523eb3763cfc82fdb4d8fb7', 'SHA256', 'CRYPT4GH', NULL, '637279707434676801000000010000006c000000000000006af1407abc74656b8913a7d323c4bfd30bf7c8ca359f74ae35357acef29dc5073799e207ec5d022b2601340585ff082565e55fbff5b6cdbbbe6b12a0d0a19ef325a219f8b62344325e22c8d26a8e82e45f053f4dcee10c0ec4bb9e466d5253f139dcd4be', 'lega_in', 'lega_in', '2021-12-13 16:18:06.512169+00', '2021-12-13 16:18:06.512169+00');"
+# insert file entry into database
+file_id=$(docker run --rm --name client --network dev_utils_default \
+    -v "dev_utils_certs:/certs" \
+    -e PGSSLCERT=/certs/client.pem \
+    -e PGSSLKEY=/certs/client-key.pem \
+    -e PGSSLROOTCERT=/certs/ca.pem \
+    neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.files (stable_id, submission_user, \
+        submission_file_path, submission_file_size, archive_file_path, \
+        archive_file_size, decrypted_file_size, backup_path, header, \
+        encryption_method) VALUES ('urn:neic:001-002', 'integration-test', 'dummy_data.c4gh', \
+        1048729, '4293c9a7-dc50-46db-b79a-27ddc0dad1c6', 1049081, 1048605, \
+        '', '637279707434676801000000010000006c000000000000006af1407abc74656b8913a7d323c4bfd30bf7c8ca359f74ae35357acef29dc5073799e207ec5d022b2601340585ff082565e55fbff5b6cdbbbe6b12a0d0a19ef325a219f8b62344325e22c8d26a8e82e45f053f4dcee10c0ec4bb9e466d5253f139dcd4be', 'CRYPT4GH') RETURNING id;" | xargs)
 
-docker run --rm --name client --network dev_utils_default -v "$PWD/certs:/certs" \
-	-e PGSSLCERT=/certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
-	neicnordic/pg-client:latest postgresql://postgres:rootpassword@db:5432/lega \
-	-t -c "INSERT INTO local_ega_ebi.filedataset (id, file_id, dataset_stable_id) VALUES (1, 1, 'https://doi.example/ty009.sfrrss/600.45asasga');"
+# insert "ready" database log event
+docker run --rm --name client --network dev_utils_default \
+    -v "dev_utils_certs:/certs" \
+    -e PGSSLCERT=/certs/client.pem \
+    -e PGSSLKEY=/certs/client-key.pem \
+    -e PGSSLROOTCERT=/certs/ca.pem \
+    neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.file_event_log (file_id, event) \
+        VALUES ('$file_id', 'ready');"
+
+docker run --rm --name client --network dev_utils_default \
+    -v "dev_utils_certs:/certs" \
+    -e PGSSLCERT=/certs/client.pem \
+    -e PGSSLKEY=/certs/client-key.pem \
+    -e PGSSLROOTCERT=/certs/ca.pem \
+	neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.checksums (file_id, checksum, type, source) \
+        VALUES ('$file_id', '06bb0a514b26497b4b41b30c547ad51d059d57fb7523eb3763cfc82fdb4d8fb7', 'SHA256', 'UNENCRYPTED');"
+
+docker run --rm --name client --network dev_utils_default \
+    -v "dev_utils_certs:/certs" \
+    -e PGSSLCERT=/certs/client.pem \
+    -e PGSSLKEY=/certs/client-key.pem \
+    -e PGSSLROOTCERT=/certs/ca.pem \
+	neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.checksums (file_id, checksum, type, source) \
+        VALUES ('$file_id', '5e9c767958cc3f6e8d16512b8b8dcab855ad1e04e05798b86f50ef600e137578', 'SHA256', 'UPLOADED');"
+
+docker run --rm --name client --network dev_utils_default \
+    -v "dev_utils_certs:/certs" \
+    -e PGSSLCERT=/certs/client.pem \
+    -e PGSSLKEY=/certs/client-key.pem \
+    -e PGSSLROOTCERT=/certs/ca.pem \
+	neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.checksums (file_id, checksum, type, source) \
+        VALUES ('$file_id', '74820dbcf9d30f8ccd1ea59c17d5ec8a714aabc065ae04e46ad82fcf300a731e', 'SHA256', 'ARCHIVED');"
+
+
+# make sure that the dataset exists in the database
+dataset_id=$(docker run --rm --name client --network dev_utils_default \
+    -v "dev_utils_certs:/certs" \
+    -e PGSSLCERT=/certs/client.pem \
+    -e PGSSLKEY=/certs/client-key.pem \
+    -e PGSSLROOTCERT=/certs/ca.pem \
+    neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.datasets (stable_id) VALUES ('https://doi.example/ty009.sfrrss/600.45asasga') \
+        ON CONFLICT (stable_id) DO UPDATE \
+        SET stable_id=excluded.stable_id RETURNING id;")
+
+# insert the file into the dataset
+docker run --rm --name client --network dev_utils_default \
+    -v "dev_utils_certs:/certs" \
+    -e PGSSLCERT=/certs/client.pem \
+    -e PGSSLKEY=/certs/client-key.pem \
+    -e PGSSLROOTCERT=/certs/ca.pem \
+    neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.file_dataset (file_id, dataset_id) \
+        VALUES ('$file_id', $dataset_id);"

--- a/.github/integration/tests/common/30_check_db.sh
+++ b/.github/integration/tests/common/30_check_db.sh
@@ -7,14 +7,14 @@ chmod 600 certs/client-key.pem
 docker run --rm --name client --network dev_utils_default -v "$PWD/certs:/certs" \
 	-e PGSSLCERT=/certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 	neicnordic/pg-client:latest postgresql://postgres:rootpassword@db:5432/lega \
-	-t -c "SELECT * from local_ega_ebi.file_dataset"
+	-t -c "SELECT * from sda.file_dataset"
 
 docker run --rm --name client --network dev_utils_default -v "$PWD/certs:/certs" \
 	-e PGSSLCERT=/certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 	neicnordic/pg-client:latest postgresql://postgres:rootpassword@db:5432/lega \
-	-t -c "SELECT * from local_ega_ebi.filedataset ORDER BY id DESC"
+	-t -c "SELECT * from sda.file_event_log"
 
 docker run --rm --name client --network dev_utils_default -v "$PWD/certs:/certs" \
 	-e PGSSLCERT=/certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
 	neicnordic/pg-client:latest postgresql://postgres:rootpassword@db:5432/lega \
-	-t -c "SELECT id, status, stable_id, archive_path FROM local_ega.files ORDER BY id DESC"
+	-t -c "SELECT id, stable_id, archive_file_path FROM sda.files ORDER BY id DESC"

--- a/.github/integration/tests/s3notls/52_check_endpoint.sh
+++ b/.github/integration/tests/s3notls/52_check_endpoint.sh
@@ -41,7 +41,7 @@ echo "got correct response when POST method used"
 # ------------------
 # Test good token
 
-token=$(curl --cacert certs/ca.pem "https://localhost:8000/tokens" | jq -r  '.[0]')
+token=$(curl "http://localhost:8000/tokens" | jq -r  '.[0]')
 
 ## Test datasets endpoint
 
@@ -89,7 +89,7 @@ fi
 # ------------------
 # Test get visas failed
 
-token=$(curl --cacert certs/ca.pem "https://localhost:8000/tokens" | jq -r  '.[1]')
+token=$(curl "http://localhost:8000/tokens" | jq -r  '.[1]')
 
 ## Test datasets endpoint
 
@@ -107,7 +107,7 @@ echo "got correct response when token has no permissions"
 # Test token with untrusted sources
 # for this test we don't attach a list of trusted sources
 
-token=$(curl --cacert certs/ca.pem "https://localhost:8000/tokens" | jq -r  '.[2]')
+token=$(curl "http://localhost:8000/tokens" | jq -r  '.[2]')
 
 ## Test datasets endpoint
 

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -24,4 +24,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3.4.0
         with:
           version: v1.51.1
-          args: -E bodyclose,gocritic,gofmt,gosec,govet,nestif,nlreturn,revive,rowserrcheck --exclude G401,G501,G107
+          args: --timeout 5m -E bodyclose,gocritic,gofmt,gosec,govet,nestif,nlreturn,revive,rowserrcheck --exclude G401,G501,G107

--- a/dev_utils/compose-no-tls.yml
+++ b/dev_utils/compose-no-tls.yml
@@ -30,7 +30,7 @@ services:
       interval: 5s
       timeout: 20s
       retries: 3
-    image: minio/minio:RELEASE.2020-06-03T22-13-49Z
+    image: minio/minio:RELEASE.2021-11-24T23-19-33Z
     ports:
       - "9000:9000"
 
@@ -68,7 +68,6 @@ services:
     volumes:
       - ./config-notls.yaml:/config.yaml
       - ./:/dev_utils/
-      - ./iss.json:/iss.json
       - ./archive_data/4293c9a7-dc50-46db-b79a-27ddc0dad1c6:/tmp/4293c9a7-dc50-46db-b79a-27ddc0dad1c6
     mem_limit: 256m
     ports:
@@ -84,7 +83,7 @@ services:
         pip install aiohttp Authlib
         python -u /mockoidc.py
     container_name: mockauth
-    image: python:3.8-slim
+    image: python:3.10-slim
     volumes:
       - ./mockoidc/mockoidc.py:/mockoidc.py
     mem_limit: 256m

--- a/dev_utils/compose-no-tls.yml
+++ b/dev_utils/compose-no-tls.yml
@@ -1,5 +1,5 @@
-version: "3.7"
 services:
+
   db:
     command: server /data
     container_name: db
@@ -13,11 +13,12 @@ services:
       interval: 5s
       timeout: 20s
       retries: 3
-    image: ghcr.io/neicnordic/sda-db:v2.0.10
+    image: ghcr.io/neicnordic/sda-db:v2.1.4
     ports:
       - "5432:5432"
     volumes:
       - /tmp/data:/data
+
   s3:
     command: server /data
     container_name: s3
@@ -29,20 +30,24 @@ services:
       interval: 5s
       timeout: 20s
       retries: 3
-    image: minio/minio:RELEASE.2021-11-24T23-19-33Z
+    image: minio/minio:RELEASE.2020-06-03T22-13-49Z
     ports:
       - "9000:9000"
+
   createbucket:
+    container_name: buckets
     image: minio/mc
     depends_on:
-      - s3
+      s3:
+        condition: service_healthy
     entrypoint: >
       /bin/sh -c "
-      sleep 10;
       /usr/bin/mc config host add s3 http://s3:9000 access secretkey;
-      /usr/bin/mc mb s3/archive || true;
+      /usr/bin/mc mb s3/archive;
       exit 0;
       "
+    restart: on-failure
+
   download:
     command: sda-download
     container_name: download
@@ -51,18 +56,25 @@ services:
         condition: service_healthy
       s3:
         condition: service_healthy
+      mockauth:
+        condition: service_started
     environment:
       - ARCHIVE_URL=http://s3
       - ARCHIVE_TYPE=s3
       - DB_HOST=db
     image: neicnordic/sda-download:latest
+    build:
+      context: ..
     volumes:
       - ./config-notls.yaml:/config.yaml
       - ./:/dev_utils/
+      - ./iss.json:/iss.json
       - ./archive_data/4293c9a7-dc50-46db-b79a-27ddc0dad1c6:/tmp/4293c9a7-dc50-46db-b79a-27ddc0dad1c6
+    mem_limit: 256m
     ports:
       - "8080:8080"
     restart: always
+
   mockauth:
     command:
       - /bin/sh
@@ -72,10 +84,9 @@ services:
         pip install aiohttp Authlib
         python -u /mockoidc.py
     container_name: mockauth
-    image: python:3.10-slim
+    image: python:3.8-slim
     volumes:
       - ./mockoidc/mockoidc.py:/mockoidc.py
-      - ./certs:/certs
     mem_limit: 256m
     ports:
       - "8000:8000"

--- a/dev_utils/compose.yml
+++ b/dev_utils/compose.yml
@@ -1,4 +1,3 @@
-version: "2.4"
 services:
   certfixer:
     command:
@@ -7,6 +6,7 @@ services:
       - |
         cp /origcerts/* /certs
         chown -R nobody.nobody /certs/*
+        chmod -R 644 /certs/*
         chmod -R og-rw /certs/*-key.pem
         chown -R 70.70 /certs/db*
         ls -la /certs/
@@ -16,11 +16,13 @@ services:
     volumes:
       - ./certs:/origcerts
       - certs:/certs
+
   db:
     command: server /data
     container_name: db
     depends_on:
-      - certfixer
+      certfixer:
+        condition: service_completed_successfully
     environment:
       - DB_LEGA_IN_PASSWORD=lega_in
       - DB_LEGA_OUT_PASSWORD=lega_out
@@ -34,12 +36,13 @@ services:
       interval: 5s
       timeout: 20s
       retries: 3
-    image: ghcr.io/neicnordic/sda-db:v2.0.10
+    image: ghcr.io/neicnordic/sda-db:v2.1.4
     ports:
       - "5432:5432"
     volumes:
       - /tmp/data:/data
       - certs:/var/lib/postgresql/tls/
+
   s3:
     command: server /data
     container_name: s3
@@ -58,30 +61,39 @@ services:
       - ./certs/ca.pem:/root/.minio/certs/CAs/public.crt
       - ./certs/s3.pem:/root/.minio/certs/public.crt
       - ./certs/s3-key.pem:/root/.minio/certs/private.key
+
   createbucket:
     container_name: buckets
     image: minio/mc
     depends_on:
-      - s3
+      s3:
+        condition: service_healthy
     entrypoint: >
       /bin/sh -c "
-      sleep 10;
       /usr/bin/mc config host add s3 https://s3:9000 access secretkey;
       /usr/bin/mc mb s3/archive;
       exit 0;
       "
     volumes:
       - ./certs/ca.pem:/etc/ssl/certs/public.crt
-    restart: always
+    restart: on-failure
+
   download:
     command: sda-download
     container_name: download
     depends_on:
-      - certfixer
-      - db
-      - mockauth
+      certfixer:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+      s3:
+        condition: service_healthy
+      mockauth:
+        condition: service_started
     env_file: ./env.download
     image: neicnordic/sda-download:latest
+    build:
+      context: ..
     volumes:
       - ./config.yaml:/config.yaml
       - ./:/dev_utils/
@@ -92,6 +104,7 @@ services:
     ports:
       - "8443:8443"
     restart: always
+
   mockauth:
     command:
       - /bin/sh

--- a/dev_utils/config-notls.yaml
+++ b/dev_utils/config-notls.yaml
@@ -30,4 +30,4 @@ oidc:
   cacert: "./dev_utils/certs/ca.pem"
   # oidc configuration API must have values for "userinfo_endpoint" and "jwks_uri"
   configuration:
-    url: "https://mockauth:8000/.well-known/openid-configuration"
+    url: "http://mockauth:8000/.well-known/openid-configuration"

--- a/dev_utils/run_integration_test.sh
+++ b/dev_utils/run_integration_test.sh
@@ -29,16 +29,85 @@ EOF
 
 chmod 444 c4gh.sec.pem
 
-docker run --rm --name client --network dev_utils_default -v "$PWD/certs:/certs" \
-	-e PGSSLCERT=/certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
-	neicnordic/pg-client:latest postgresql://postgres:rootpassword@db:5432/lega \
-	-t -c "INSERT INTO local_ega.main (id, stable_id, status, submission_file_path, submission_file_extension, submission_file_calculated_checksum, submission_file_calculated_checksum_type, submission_file_size, submission_user, archive_file_reference, archive_file_type, archive_file_size, archive_file_checksum, archive_file_checksum_type, decrypted_file_size, decrypted_file_checksum, decrypted_file_checksum_type, encryption_method, version, header, created_by, last_modified_by, created_at, last_modified) VALUES (1, 'urn:neic:001-002', 'READY', 'dummy_data.c4gh', 'c4gh', '5e9c767958cc3f6e8d16512b8b8dcab855ad1e04e05798b86f50ef600e137578', 'SHA256', NULL, 'test', '4293c9a7-dc50-46db-b79a-27ddc0dad1c6', NULL, 1049081, '74820dbcf9d30f8ccd1ea59c17d5ec8a714aabc065ae04e46ad82fcf300a731e', 'SHA256', 1048605, '06bb0a514b26497b4b41b30c547ad51d059d57fb7523eb3763cfc82fdb4d8fb7', 'SHA256', 'CRYPT4GH', NULL, '637279707434676801000000010000006c000000000000006af1407abc74656b8913a7d323c4bfd30bf7c8ca359f74ae35357acef29dc5073799e207ec5d022b2601340585ff082565e55fbff5b6cdbbbe6b12a0d0a19ef325a219f8b62344325e22c8d26a8e82e45f053f4dcee10c0ec4bb9e466d5253f139dcd4be', 'lega_in', 'lega_in', '2021-12-13 16:18:06.512169+00', '2021-12-13 16:18:06.512169+00');"
+# insert file entry into database
+file_id=$(docker run --rm --name client --network dev_utils_default \
+    -v "dev_utils_certs:/certs" \
+    -e PGSSLCERT=/certs/client.pem \
+    -e PGSSLKEY=/certs/client-key.pem \
+    -e PGSSLROOTCERT=/certs/ca.pem \
+    neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.files (stable_id, submission_user, \
+        submission_file_path, submission_file_size, archive_file_path, \
+        archive_file_size, decrypted_file_size, backup_path, header, \
+        encryption_method) VALUES ('urn:neic:001-002', 'integration-test', 'dummy_data.c4gh', \
+        1048729, '4293c9a7-dc50-46db-b79a-27ddc0dad1c6', 1049081, 1048605, \
+        '', '637279707434676801000000010000006c000000000000006af1407abc74656b8913a7d323c4bfd30bf7c8ca359f74ae35357acef29dc5073799e207ec5d022b2601340585ff082565e55fbff5b6cdbbbe6b12a0d0a19ef325a219f8b62344325e22c8d26a8e82e45f053f4dcee10c0ec4bb9e466d5253f139dcd4be', 'CRYPT4GH') RETURNING id;" | xargs)
 
-docker run --rm --name client --network dev_utils_default -v "$PWD/certs:/certs" \
-	-e PGSSLCERT=/certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
-	neicnordic/pg-client:latest postgresql://postgres:rootpassword@db:5432/lega \
-	-t -c "INSERT INTO local_ega_ebi.filedataset (id, file_id, dataset_stable_id) VALUES (1, 1, 'https://doi.example/ty009.sfrrss/600.45asasga');"
+# insert "ready" database log event
+docker run --rm --name client --network dev_utils_default \
+    -v "dev_utils_certs:/certs" \
+    -e PGSSLCERT=/certs/client.pem \
+    -e PGSSLKEY=/certs/client-key.pem \
+    -e PGSSLROOTCERT=/certs/ca.pem \
+    neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.file_event_log (file_id, event) \
+        VALUES ('$file_id', 'ready');"
 
+docker run --rm --name client --network dev_utils_default \
+    -v "dev_utils_certs:/certs" \
+    -e PGSSLCERT=/certs/client.pem \
+    -e PGSSLKEY=/certs/client-key.pem \
+    -e PGSSLROOTCERT=/certs/ca.pem \
+	neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.checksums (file_id, checksum, type, source) \
+        VALUES ('$file_id', '06bb0a514b26497b4b41b30c547ad51d059d57fb7523eb3763cfc82fdb4d8fb7', 'SHA256', 'UNENCRYPTED');"
+
+docker run --rm --name client --network dev_utils_default \
+    -v "dev_utils_certs:/certs" \
+    -e PGSSLCERT=/certs/client.pem \
+    -e PGSSLKEY=/certs/client-key.pem \
+    -e PGSSLROOTCERT=/certs/ca.pem \
+	neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.checksums (file_id, checksum, type, source) \
+        VALUES ('$file_id', '5e9c767958cc3f6e8d16512b8b8dcab855ad1e04e05798b86f50ef600e137578', 'SHA256', 'UPLOADED');"
+
+docker run --rm --name client --network dev_utils_default \
+    -v "dev_utils_certs:/certs" \
+    -e PGSSLCERT=/certs/client.pem \
+    -e PGSSLKEY=/certs/client-key.pem \
+    -e PGSSLROOTCERT=/certs/ca.pem \
+	neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.checksums (file_id, checksum, type, source) \
+        VALUES ('$file_id', '74820dbcf9d30f8ccd1ea59c17d5ec8a714aabc065ae04e46ad82fcf300a731e', 'SHA256', 'ARCHIVED');"
+
+
+# make sure that the dataset exists in the database
+dataset_id=$(docker run --rm --name client --network dev_utils_default \
+    -v "dev_utils_certs:/certs" \
+    -e PGSSLCERT=/certs/client.pem \
+    -e PGSSLKEY=/certs/client-key.pem \
+    -e PGSSLROOTCERT=/certs/ca.pem \
+    neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.datasets (stable_id) VALUES ('https://doi.example/ty009.sfrrss/600.45asasga') \
+        ON CONFLICT (stable_id) DO UPDATE \
+        SET stable_id=excluded.stable_id RETURNING id;")
+
+# insert the file into the dataset
+docker run --rm --name client --network dev_utils_default \
+    -v "dev_utils_certs:/certs" \
+    -e PGSSLCERT=/certs/client.pem \
+    -e PGSSLKEY=/certs/client-key.pem \
+    -e PGSSLROOTCERT=/certs/ca.pem \
+    neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.file_dataset (file_id, dataset_id) \
+        VALUES ('$file_id', $dataset_id);"
 
 # Make buckets if they don't exist already
 s3cmd -c s3cmd.conf mb s3://archive || true

--- a/dev_utils/run_integration_test_no_tls.sh
+++ b/dev_utils/run_integration_test_no_tls.sh
@@ -9,8 +9,6 @@ do
     fi
 done
 
-chmod 600 certs/client-key.pem
-
 cat << EOF > c4gh.pub.pem
 -----BEGIN CRYPT4GH PUBLIC KEY-----
 avFAerx0ZWuJE6fTI8S/0wv3yMo1n3SuNTV6zvKdxQc=
@@ -29,16 +27,58 @@ EOF
 
 chmod 444 c4gh.sec.pem
 
-docker run --rm --name client --network dev_utils_default -v "$PWD/certs:/certs" \
-	-e PGSSLCERT=/certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
-	neicnordic/pg-client:latest postgresql://postgres:rootpassword@db:5432/lega \
-	-t -c "INSERT INTO local_ega.main (id, stable_id, status, submission_file_path, submission_file_extension, submission_file_calculated_checksum, submission_file_calculated_checksum_type, submission_file_size, submission_user, archive_file_reference, archive_file_type, archive_file_size, archive_file_checksum, archive_file_checksum_type, decrypted_file_size, decrypted_file_checksum, decrypted_file_checksum_type, encryption_method, version, header, created_by, last_modified_by, created_at, last_modified) VALUES (1, 'urn:neic:001-002', 'READY', 'dummy_data.c4gh', 'c4gh', '5e9c767958cc3f6e8d16512b8b8dcab855ad1e04e05798b86f50ef600e137578', 'SHA256', NULL, 'test', '4293c9a7-dc50-46db-b79a-27ddc0dad1c6', NULL, 1049081, '74820dbcf9d30f8ccd1ea59c17d5ec8a714aabc065ae04e46ad82fcf300a731e', 'SHA256', 1048605, '06bb0a514b26497b4b41b30c547ad51d059d57fb7523eb3763cfc82fdb4d8fb7', 'SHA256', 'CRYPT4GH', NULL, '637279707434676801000000010000006c000000000000006af1407abc74656b8913a7d323c4bfd30bf7c8ca359f74ae35357acef29dc5073799e207ec5d022b2601340585ff082565e55fbff5b6cdbbbe6b12a0d0a19ef325a219f8b62344325e22c8d26a8e82e45f053f4dcee10c0ec4bb9e466d5253f139dcd4be', 'lega_in', 'lega_in', '2021-12-13 16:18:06.512169+00', '2021-12-13 16:18:06.512169+00');"
 
-docker run --rm --name client --network dev_utils_default -v "$PWD/certs:/certs" \
-	-e PGSSLCERT=/certs/client.pem -e PGSSLKEY=/certs/client-key.pem -e PGSSLROOTCERT=/certs/ca.pem \
-	neicnordic/pg-client:latest postgresql://postgres:rootpassword@db:5432/lega \
-	-t -c "INSERT INTO local_ega_ebi.filedataset (id, file_id, dataset_stable_id) VALUES (1, 1, 'https://doi.example/ty009.sfrrss/600.45asasga');"
+# insert file entry into database
+file_id=$(docker run --rm --name client --network dev_utils_default \
+    neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.files (stable_id, submission_user, \
+        submission_file_path, submission_file_size, archive_file_path, \
+        archive_file_size, decrypted_file_size, backup_path, header, \
+        encryption_method) VALUES ('urn:neic:001-002', 'integration-test', 'dummy_data.c4gh', \
+        1048729, '4293c9a7-dc50-46db-b79a-27ddc0dad1c6', 1049081, 1048605, \
+        '', '637279707434676801000000010000006c000000000000006af1407abc74656b8913a7d323c4bfd30bf7c8ca359f74ae35357acef29dc5073799e207ec5d022b2601340585ff082565e55fbff5b6cdbbbe6b12a0d0a19ef325a219f8b62344325e22c8d26a8e82e45f053f4dcee10c0ec4bb9e466d5253f139dcd4be', 'CRYPT4GH') RETURNING id;" | xargs)
 
+# insert "ready" database log event
+docker run --rm --name client --network dev_utils_default \
+    neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.file_event_log (file_id, event) \
+        VALUES ('$file_id', 'ready');"
+
+docker run --rm --name client --network dev_utils_default \
+	neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.checksums (file_id, checksum, type, source) \
+        VALUES ('$file_id', '06bb0a514b26497b4b41b30c547ad51d059d57fb7523eb3763cfc82fdb4d8fb7', 'SHA256', 'UNENCRYPTED');"
+
+docker run --rm --name client --network dev_utils_default \
+	neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.checksums (file_id, checksum, type, source) \
+        VALUES ('$file_id', '5e9c767958cc3f6e8d16512b8b8dcab855ad1e04e05798b86f50ef600e137578', 'SHA256', 'UPLOADED');"
+
+docker run --rm --name client --network dev_utils_default \
+	neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.checksums (file_id, checksum, type, source) \
+        VALUES ('$file_id', '74820dbcf9d30f8ccd1ea59c17d5ec8a714aabc065ae04e46ad82fcf300a731e', 'SHA256', 'ARCHIVED');"
+
+
+# make sure that the dataset exists in the database
+dataset_id=$(docker run --rm --name client --network dev_utils_default \
+    neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.datasets (stable_id) VALUES ('https://doi.example/ty009.sfrrss/600.45asasga') \
+        ON CONFLICT (stable_id) DO UPDATE \
+        SET stable_id=excluded.stable_id RETURNING id;")
+
+# insert the file into the dataset
+docker run --rm --name client --network dev_utils_default \
+    neicnordic/pg-client:latest \
+    postgresql://postgres:rootpassword@db:5432/lega \
+    -t -q -c "INSERT INTO sda.file_dataset (file_id, dataset_id) \
+        VALUES ('$file_id', $dataset_id);"
 
 # Make buckets if they don't exist already
 s3cmd -c s3cmd-notls.conf mb s3://archive || true
@@ -61,7 +101,7 @@ echo "Health endpoint is ok"
 
 # Test empty token
 
-check_401=$(curl -o /dev/null -s -w "%{http_code}\n" http://localhost:8080/metadata/datasets)
+check_401=$(curl -o /dev/null -s -w "%{http_code}\n" -X GET http://localhost:8080/metadata/datasets)
 
 if [ "$check_401" != "401" ]; then
     echo "no token provided should give 401"
@@ -70,7 +110,6 @@ if [ "$check_401" != "401" ]; then
 fi
 
 echo "got correct response when no token provided"
-
 
 check_405=$(curl -X POST -o /dev/null -s -w "%{http_code}\n" http://localhost:8080/metadata/datasets )
 
@@ -84,7 +123,7 @@ echo "got correct response when POST method used"
 
 # Test good token
 
-token=$(curl --cacert certs/ca.pem "https://localhost:8000/tokens" | jq -r  '.[0]')
+token=$(curl "http://localhost:8000/tokens" | jq -r  '.[0]')
 
 ## Test datasets endpoint
 
@@ -130,7 +169,7 @@ fi
 
 # Test get visas failed
 
-token=$(curl --cacert certs/ca.pem "https://localhost:8000/tokens" | jq -r  '.[1]')
+token=$(curl "http://localhost:8000/tokens" | jq -r  '.[1]')
 
 ## Test datasets endpoint
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -152,9 +152,30 @@ func (dbs *SQLdb) getFiles(datasetID string) ([]*FileInfo, error) {
 	files := []*FileInfo{}
 	db := dbs.DB
 
-	const query = "SELECT a.file_id, dataset_id, display_file_name, file_name, file_size, " +
-		"decrypted_file_size, decrypted_file_checksum, decrypted_file_checksum_type, file_status from " +
-		"local_ega_ebi.file a, local_ega_ebi.file_dataset b WHERE dataset_id = $1 AND a.file_id=b.file_id;"
+	const query = `
+		SELECT f.stable_id AS file_id,
+			d.stable_id AS dataset_id,
+			reverse(split_part(reverse(f.submission_file_path::text), '/'::text, 1)) AS display_file_name,
+			f.archive_file_path AS file_name,
+			f.archive_file_size AS file_size,
+			f.decrypted_file_size,
+			dc.checksum AS decrypted_file_checksum,
+			dc.type AS decrypted_file_checksum_type,
+			e.event AS status
+		FROM sda.files f
+		JOIN sda.file_dataset fd ON fd.file_id = f.id
+		JOIN sda.datasets d ON fd.dataset_id = d.id
+		LEFT JOIN (SELECT file_id,
+					(ARRAY_AGG(event ORDER BY started_at DESC))[1] AS event
+				FROM sda.file_event_log
+				GROUP BY file_id) e
+		ON f.id = e.file_id
+		LEFT JOIN (SELECT file_id, checksum, type
+			FROM sda.checksums
+		WHERE source = 'UNENCRYPTED') dc
+		ON f.id = dc.file_id
+		WHERE d.stable_id = $1;
+	  	`
 
 	// nolint:rowserrcheck
 	rows, err := db.Query(query, datasetID)
@@ -222,7 +243,7 @@ func (dbs *SQLdb) checkDataset(dataset string) (bool, error) {
 	dbs.checkAndReconnectIfNeeded()
 
 	db := dbs.DB
-	const query = "SELECT DISTINCT dataset_id FROM local_ega_ebi.file_dataset WHERE dataset_id = $1"
+	const query = "SELECT stable_id FROM sda.datasets WHERE stable_id = $1"
 
 	var datasetName string
 	if err := db.QueryRow(query, dataset).Scan(&datasetName); err != nil {
@@ -261,7 +282,7 @@ func (dbs *SQLdb) checkFilePermission(fileID string) (string, error) {
 	log.Debugf("check permissions for file with %s", sanitizeString(fileID))
 
 	db := dbs.DB
-	const query = "SELECT dataset_id FROM local_ega_ebi.file_dataset WHERE file_id = $1"
+	const query = "SELECT d.stable_id FROM sda.file_dataset fd JOIN sda.datasets d ON fd.dataset_id = d.id JOIN sda.files f ON fd.file_id = f.id WHERE f.stable_id = $1"
 
 	var datasetName string
 	if err := db.QueryRow(query, fileID).Scan(&datasetName); err != nil {
@@ -308,7 +329,12 @@ func (dbs *SQLdb) getFile(fileID string) (*FileDownload, error) {
 	log.Debugf("check details for file with %s", sanitizeString(fileID))
 
 	db := dbs.DB
-	const query = "SELECT file_path, archive_file_size, header FROM local_ega_ebi.file WHERE file_id = $1"
+	const query = `
+		SELECT f.archive_file_path,
+			   f.archive_file_size,
+			   f.header
+		FROM sda.files f
+		WHERE stable_id = $1`
 
 	fd := &FileDownload{}
 	var hexString string

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -168,7 +168,7 @@ func (dbs *SQLdb) getFiles(datasetID string) ([]*FileInfo, error) {
 		LEFT JOIN (SELECT file_id, (ARRAY_AGG(event ORDER BY started_at DESC))[1] AS event FROM sda.file_event_log GROUP BY file_id) log ON files.id = log.file_id
 		LEFT JOIN (SELECT file_id, checksum, type FROM sda.checksums WHERE source = 'UNENCRYPTED') sha ON files.id = sha.file_id
 		WHERE datasets.stable_id = $1;
-	  `
+	`
 
 	// nolint:rowserrcheck
 	rows, err := db.Query(query, datasetID)

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -200,12 +200,7 @@ func TestCheckFilePermission(t *testing.T) {
 	r := sqlTesterHelper(t, func(mock sqlmock.Sqlmock, testDb *SQLdb) error {
 
 		expected := "dataset1"
-		query := `
-			SELECT datasets.stable_id FROM sda.file_dataset
-			JOIN sda.datasets ON file_dataset.dataset_id = datasets.id
-			JOIN sda.files ON file_dataset.file_id = files.id
-			WHERE files.stable_id = $1;
-		`
+		query := "SELECT datasets.stable_id FROM sda.file_dataset JOIN sda.datasets ON dataset_id = datasets.id JOIN sda.files ON file_id = files.id WHERE files.stable_id = \\$1;"
 		mock.ExpectQuery(query).
 			WithArgs("file1").
 			WillReturnRows(sqlmock.NewRows([]string{"dataset_id"}).AddRow("dataset1"))
@@ -261,11 +256,7 @@ func TestGetFile(t *testing.T) {
 			ArchiveSize: 32,
 			Header:      []byte{171, 193, 35},
 		}
-		query := `
-			SELECT archive_file_path, archive_file_size, header
-			FROM sda.files
-			WHERE stable_id = $1
-		`
+		query := "SELECT archive_file_path, archive_file_size, header FROM sda.files WHERE stable_id = \\$1;"
 
 		mock.ExpectQuery(query).
 			WithArgs("file1").
@@ -303,30 +294,8 @@ func TestGetFiles(t *testing.T) {
 			Status:                    "ready",
 		}
 		expected = append(expected, fileInfo)
-		query := `
-		SELECT f.stable_id AS file_id,
-			d.stable_id AS dataset_id,
-			reverse\(split_part\(reverse\(f.submission_file_path::text\), '/'::text, 1\)\) AS display_file_name,
-			f.archive_file_path AS file_name,
-			f.archive_file_size AS file_size,
-			f.decrypted_file_size,
-			dc.checksum AS decrypted_file_checksum,
-			dc.type AS decrypted_file_checksum_type,
-			e.event AS status
-		FROM sda.files f
-		JOIN sda.file_dataset fd ON fd.file_id = f.id
-		JOIN sda.datasets d ON fd.dataset_id = d.id
-		LEFT JOIN \(SELECT file_id,
-					\(ARRAY_AGG\(event ORDER BY started_at DESC\)\)\[1\] AS event
-				FROM sda.file_event_log
-				GROUP BY file_id\) e
-		ON f.id = e.file_id
-		LEFT JOIN \(SELECT file_id, checksum, type
-			FROM sda.checksums
-		WHERE source = 'UNENCRYPTED'\) dc
-		ON f.id = dc.file_id
-	  	WHERE d.stable_id = \$1;
-	  	`
+		query := "SELECT files.stable_id AS id, datasets.stable_id AS dataset_id, reverse\\(split_part\\(reverse\\(files.submission_file_path::text\\), '/'::text, 1\\)\\) AS display_file_name, files.archive_file_path AS file_name, files.archive_file_size AS file_size, files.decrypted_file_size, sha.checksum AS decrypted_file_checksum, sha.type AS decrypted_file_checksum_type, log.event AS status FROM sda.files JOIN sda.file_dataset ON file_id = files.id JOIN sda.datasets ON file_dataset.dataset_id = datasets.id LEFT JOIN \\(SELECT file_id, \\(ARRAY_AGG\\(event ORDER BY started_at DESC\\)\\)\\[1\\] AS event FROM sda.file_event_log GROUP BY file_id\\) log ON files.id = log.file_id LEFT JOIN \\(SELECT file_id, checksum, type FROM sda.checksums WHERE source = 'UNENCRYPTED'\\) sha ON files.id = sha.file_id WHERE datasets.stable_id = \\$1;"
+
 		mock.ExpectQuery(query).
 			WithArgs("dataset1").
 			WillReturnRows(sqlmock.NewRows([]string{"file_id", "dataset_id",


### PR DESCRIPTION
This PR converts the sda-download database queries to directly use the v2 schema instead of the `local_ega_ebi` schema.

This is the first step of #246 (which likes to have timestamps not available in the `local_ega_ebi` schema).