### PR TITLE
Remove write timeout

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -56,7 +56,7 @@ func Setup() *http.Server {
 		TLSNextProto:      make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
 		ReadHeaderTimeout: 20 * time.Second,
 		ReadTimeout:       5 * time.Minute,
-		WriteTimeout:      20 * time.Second,
+		WriteTimeout:      -1,
 	}
 
 	return srv


### PR DESCRIPTION
The download is time-outing after 20 seconds, therefore, not allowing for big files to be downloaded. The PR is removing this timeout completely.