### PR TITLE
check for /files suffix in API path for dataset

### DIFF
--- a/api/sda/sda.go
+++ b/api/sda/sda.go
@@ -83,8 +83,16 @@ var getFiles = func(datasetID string, ctx *gin.Context) ([]*database.FileInfo, i
 // Files serves a list of files belonging to a dataset
 func Files(c *gin.Context) {
 
-	// get dataset parameter, remove / prefix and /files suffix
+	// get dataset parameter
 	dataset := c.Param("dataset")
+
+	if !strings.HasSuffix(dataset, "/files") {
+		c.String(http.StatusNotFound, "API path not found, maybe /files is missing")
+
+		return
+	}
+
+	// remove / prefix and /files suffix
 	dataset = strings.TrimPrefix(dataset, "/")
 	dataset = strings.TrimSuffix(dataset, "/files")
 

--- a/api/sda/sda_test.go
+++ b/api/sda/sda_test.go
@@ -229,6 +229,12 @@ func TestFiles_Fail(t *testing.T) {
 	// Mock request and response holders
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
+	c.Params = []gin.Param{
+		{
+			Key:   "dataset",
+			Value: "dataset1/files",
+		},
+	}
 
 	// Test the outcomes of the handler
 	Files(c)
@@ -283,6 +289,12 @@ func TestFiles_Success(t *testing.T) {
 	// Mock request and response holders
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
+	c.Params = []gin.Param{
+		{
+			Key:   "dataset",
+			Value: "dataset1/files",
+		},
+	}
 
 	// Test the outcomes of the handler
 	Files(c)


### PR DESCRIPTION
route for `/metadata/datasets/<datasetid>/files` was not properly checked allowing responses to `/metadata/datasets/<datasetid>`. This fixes that