### PR TITLE
retrieve files with status only ready

### DIFF
--- a/api/s3/s3_test.go
+++ b/api/s3/s3_test.go
@@ -149,7 +149,7 @@ func (suite *S3TestSuite) TestListByPrefix() {
 		FROM sda.files
 		JOIN sda.file_dataset ON file_id = files.id
 		JOIN sda.datasets ON file_dataset.dataset_id = datasets.id
-		LEFT JOIN \(SELECT file_id, \(ARRAY_AGG\(event ORDER BY started_at DESC\)\)\[1\] AS event FROM sda.file_event_log GROUP BY file_id\) log ON files.id = log.file_id
+		LEFT JOIN \(SELECT file_id, event FROM sda.file_event_log WHERE event = 'ready'\) log ON files.id = log.file_id
 		LEFT JOIN \(SELECT file_id, checksum, type FROM sda.checksums WHERE source = 'UNENCRYPTED'\) sha ON files.id = sha.file_id
 		WHERE datasets.stable_id = \$1;
 		`
@@ -228,7 +228,7 @@ func (suite *S3TestSuite) TestListObjects() {
 		FROM sda.files
 		JOIN sda.file_dataset ON file_id = files.id
 		JOIN sda.datasets ON file_dataset.dataset_id = datasets.id
-		LEFT JOIN \(SELECT file_id, \(ARRAY_AGG\(event ORDER BY started_at DESC\)\)\[1\] AS event FROM sda.file_event_log GROUP BY file_id\) log ON files.id = log.file_id
+		LEFT JOIN \(SELECT file_id, event FROM sda.file_event_log WHERE event = 'ready'\) log ON files.id = log.file_id
 		LEFT JOIN \(SELECT file_id, checksum, type FROM sda.checksums WHERE source = 'UNENCRYPTED'\) sha ON files.id = sha.file_id
 		WHERE datasets.stable_id = \$1;
 		`

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -176,7 +176,7 @@ func (dbs *SQLdb) getFiles(datasetID string) ([]*FileInfo, error) {
 		FROM sda.files
 		JOIN sda.file_dataset ON file_id = files.id
 		JOIN sda.datasets ON file_dataset.dataset_id = datasets.id
-		LEFT JOIN (SELECT file_id, (ARRAY_AGG(event ORDER BY started_at DESC))[1] AS event FROM sda.file_event_log GROUP BY file_id) log ON files.id = log.file_id
+		LEFT JOIN (SELECT file_id, event FROM sda.file_event_log WHERE event = 'ready') log ON files.id = log.file_id
 		LEFT JOIN (SELECT file_id, checksum, type FROM sda.checksums WHERE source = 'UNENCRYPTED') sha ON files.id = sha.file_id
 		WHERE datasets.stable_id = $1;
 	  	`
@@ -341,10 +341,7 @@ func (dbs *SQLdb) getDatasetFileInfo(datasetID, filePath string) (*FileInfo, err
 		FROM sda.files f
 		JOIN sda.file_dataset fd ON fd.file_id = f.id
 		JOIN sda.datasets d ON fd.dataset_id = d.id
-		LEFT JOIN (SELECT file_id,
-					(ARRAY_AGG(event ORDER BY started_at DESC))[1] AS event
-				FROM sda.file_event_log
-				GROUP BY file_id) e
+		LEFT JOIN (SELECT file_id, event FROM sda.file_event_log WHERE event = 'ready') e
 		ON f.id = e.file_id
 		LEFT JOIN (SELECT file_id, checksum, type
 			FROM sda.checksums

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -317,10 +317,7 @@ func TestGetDatasetFileInfo(t *testing.T) {
 		FROM sda.files f
 		JOIN sda.file_dataset fd ON fd.file_id = f.id
 		JOIN sda.datasets d ON fd.dataset_id = d.id
-		LEFT JOIN \(SELECT file_id,
-					\(ARRAY_AGG\(event ORDER BY started_at DESC\)\)\[1\] AS event
-				FROM sda.file_event_log
-				GROUP BY file_id\) e
+		LEFT JOIN \(SELECT file_id, event FROM sda.file_event_log WHERE event = 'ready'\) e
 		ON f.id = e.file_id
 		LEFT JOIN \(SELECT file_id, checksum, type
 			FROM sda.checksums
@@ -439,7 +436,7 @@ func TestGetFiles(t *testing.T) {
 			FROM sda.files
 			JOIN sda.file_dataset ON file_id = files.id
 			JOIN sda.datasets ON file_dataset.dataset_id = datasets.id
-			LEFT JOIN \(SELECT file_id, \(ARRAY_AGG\(event ORDER BY started_at DESC\)\)\[1\] AS event FROM sda.file_event_log GROUP BY file_id\) log ON files.id = log.file_id
+			LEFT JOIN \(SELECT file_id, event FROM sda.file_event_log WHERE event = 'ready'\) log ON files.id = log.file_id
 			LEFT JOIN \(SELECT file_id, checksum, type FROM sda.checksums WHERE source = 'UNENCRYPTED'\) sha ON files.id = sha.file_id
 			WHERE datasets.stable_id = \$1;
 		`


### PR DESCRIPTION
in the database the latest status might not always be the `ready` status, this restricts that so that we retrieve files with status `ready`.

even though the file-mapping is done, when retrieving the file it is good to only get files in status ready indifferent from when that was recorded.